### PR TITLE
feat(design-system): added a placeholder module and story for colors

### DIFF
--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -8,7 +8,7 @@ export const parameters = {
   },
   options: {
     storySort: {
-      order: ['Getting Started', 'Components']
+      order: ['Getting Started', 'Foundation', 'Components']
     },
   },
 }

--- a/packages/design-system/src/foundation/colors/index.ts
+++ b/packages/design-system/src/foundation/colors/index.ts
@@ -1,0 +1,1 @@
+// Main module for Foundation > Colors

--- a/packages/design-system/src/stories/foundation/colors/Colors.stories.tsx
+++ b/packages/design-system/src/stories/foundation/colors/Colors.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+const Colors = () => {
+  return null;
+};
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
+  title: "Foundation/Colors",
+  component: Colors,
+  argTypes: {
+    backgroundColor: { control: "color" },
+  },
+} as ComponentMeta<typeof Colors>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof Colors> = () => <Colors />;
+
+export const Main = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+Main.args = {
+  primary: true,
+  label: "Hello World",
+};


### PR DESCRIPTION
I added a placeholder module and story for Colors in Lunit Design System Foundation.
* I added a `foundation` folder at the same level as `components` folder since we might have some modules that don't have corresponding React components in Foundation. 
* I also added a "Foundation" section in our storybook.