### PR TITLE
[design-system-icons] Fix typo in icon installation guide storybook

### DIFF
--- a/packages/design-system-icons/src/stories/Introduction.stories.mdx
+++ b/packages/design-system-icons/src/stories/Introduction.stories.mdx
@@ -19,10 +19,10 @@ import SuccessIcon from "../../dist/Success";
 
 ```shell
 # with npm
-npm install @lunit/design-system-icon
+npm install @lunit/design-system-icons
 
 # with yarn
-yarn add @lunit/design-system-icon
+yarn add @lunit/design-system-icons
 ```
 
 ## Usage

--- a/packages/design-system-icons/src/stories/Introduction.stories.mdx
+++ b/packages/design-system-icons/src/stories/Introduction.stories.mdx
@@ -31,9 +31,9 @@ Icons in this package is using [SvgIcon](https://mui.com/components/icons/#svgic
 
 ```tsx
 // Option 1
-import SuccessIcon from "@lunit/design-system-icon/Success";
+import SuccessIcon from "@lunit/design-system-icons/Success";
 // Option 2
-import { Success } from "@lunit/design-system-icon";
+import { Success } from "@lunit/design-system-icons";
 
 <Success />
 // You can use any of SvgIcon props


### PR DESCRIPTION
# Description
- Add `s` to `icon`(icon -> icons)
