### PR TITLE
[LDS-43] storybook, chromatic deploy

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,11 +16,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Get branch name
+        id: branch-name
+        run: |
+          echo "::set-output name=value::$(echo ${GITHUB_REF_NAME} | tr / -)"
+
       - name: Install dependencies
         run: yarn
         working-directory: ${{ env.WORKDIR }}
 
       - name: Publish to Chromatic
+        env:
+          BRANCH_NAME: ${{ steps.branch-name.outputs.value }}
+          CHROMATIC_APP_ID: "62d7d1f2efc8a1e364b5e5e8"
         id: chromatic
         uses: chromaui/action@v1
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,11 @@
 # Workflow name
 name: "Chromatic Deployment"
 
+env:
+  CHROMATIC_APP_ID: 62d7d1f2efc8a1e364b5e5e8
+
 # Event for the workflow
-on: push
+on: [push, pull_request]
 
 # List of jobs
 jobs:
@@ -17,21 +20,42 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Get branch name
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         id: branch-name
         run: |
-          echo "::set-output name=value::$(echo ${GITHUB_REF_NAME} | tr / -)"
+          echo "::set-output name=value::$(echo $BRANCH_NAME)"
+
+      - name: Get Chromatic branch name
+        env:
+          BRANCH_NAME: ${{ steps.branch-name.outputs.value }}
+        id: chromatic-branch-name
+        run: |
+          echo "::set-output name=value::$(echo $BRANCH_NAME | tr '[:upper:]' '[:lower:]' | tr / -)"
 
       - name: Install dependencies
+        if: ${{ github.event_name == 'push' }}
         run: yarn
         working-directory: ${{ env.WORKDIR }}
 
       - name: Publish to Chromatic
         env:
           BRANCH_NAME: ${{ steps.branch-name.outputs.value }}
-          CHROMATIC_APP_ID: "62d7d1f2efc8a1e364b5e5e8"
+          CHROMATIC_BRANCH_NAME: ${{ steps.chromatic-branch-name.outputs.value }}
         id: chromatic
+        if: ${{ github.event_name == 'push' }}
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           workingDir: ${{ env.WORKDIR }}
+
+      - name: Comment preview link
+        env:
+          CHROMATIC_BRANCH_NAME: ${{ steps.chromatic-branch-name.outputs.value }}
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: NejcZdovc/comment-pr@v1.1.1
+        with:
+          message: "preview: https://${{ env.CHROMATIC_BRANCH_NAME }}--${{ env.CHROMATIC_APP_ID }}.chromatic.com"
+          identifier: "PREVIEW_LINK_COMMENT"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,29 @@
+# Workflow name
+name: "Chromatic Deployment"
+
+# Event for the workflow
+on: push
+
+# List of jobs
+jobs:
+  deploy-staging:
+    # Operating System
+    runs-on: ubuntu-latest
+    env:
+      WORKDIR: ./packages/design-system
+    # Job steps
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install dependencies
+        run: yarn
+        working-directory: ${{ env.WORKDIR }}
+
+      - name: Publish to Chromatic
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          workingDir: ${{ env.WORKDIR }}

--- a/packages/design-system/.storybook/Welcome/Welcome.tsx
+++ b/packages/design-system/.storybook/Welcome/Welcome.tsx
@@ -1,9 +1,25 @@
+import { Alert, Link } from "@mui/material";
 import React from "react";
+
+const BRANCH_NAME = process.env.BRANCH_NAME;
+const CHROMATIC_BRANCH_NAME = process.env.CHROMATIC_BRANCH_NAME;
+const CHROMATIC_APP_ID = process.env.CHROMATIC_APP_ID;
+
+const branchHostname = CHROMATIC_BRANCH_NAME
+  ? `${CHROMATIC_BRANCH_NAME}--${CHROMATIC_APP_ID}.chromatic.com`
+  : undefined;
 
 export const Welcome = () => {
   return (
     <div>
       <h2>Lunit Design System</h2>
+      {branchHostname != null && branchHostname !== window.location.hostname && (
+        <Alert severity="info">
+          Checkout the latest version for the current branch(
+          <code>{BRANCH_NAME}</code>){" "}
+          <Link href={`//${branchHostname}`}>here</Link>.
+        </Alert>
+      )}
     </div>
   );
 };

--- a/packages/design-system/.storybook/branch.js
+++ b/packages/design-system/.storybook/branch.js
@@ -29,4 +29,11 @@ function getBranchName() {
   return branchName ?? head.trim();
 }
 
-module.exports = getBranchName;
+function getChromaticBranchName() {
+  return getBranchName()?.toLowerCase().replace("/g", "-");
+}
+
+module.exports = {
+  getBranchName,
+  getChromaticBranchName,
+};

--- a/packages/design-system/.storybook/branch.js
+++ b/packages/design-system/.storybook/branch.js
@@ -1,0 +1,32 @@
+const path = require("path");
+const fs = require("fs");
+
+const PATH_SEP = path.sep;
+const REF_BRANCH = /^ref: refs\/heads\/(.*)\n/;
+
+function getRepoDirname(startPath = module.parent.filename) {
+  if (!startPath.length) {
+    throw new Error("No git repository found");
+  }
+
+  const gitDirname = path.resolve(startPath, ".git");
+
+  if (!fs.existsSync(gitDirname)) {
+    const paths = startPath.split(PATH_SEP);
+    paths.pop();
+    return getRepoDirname(paths.join(PATH_SEP));
+  }
+
+  return gitDirname;
+}
+
+function getBranchName() {
+  const repoDirname = getRepoDirname();
+
+  const head = fs.readFileSync(path.resolve(repoDirname, "HEAD"), "utf8");
+  const branchName = head.match(REF_BRANCH)?.[1];
+
+  return branchName ?? head.trim();
+}
+
+module.exports = getBranchName;

--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const alias = require("../config/alias");
+const getBranchName = require("./branch");
 
 module.exports = {
   features: {
@@ -27,6 +28,15 @@ module.exports = {
       },
     },
   ],
+  env: (config) => ({
+    ...config,
+    BRANCH_NAME: process.env.BRANCH_NAME ?? getBranchName(),
+    CHROMATIC_APP_ID:
+      process.env.CHROMATIC_APP_ID ?? "62d7d1f2efc8a1e364b5e5e8",
+    CHROMATIC_BRANCH_NAME: (process.env.BRANCH_NAME ?? getBranchName())
+      ?.toLowerCase()
+      .replace("/g", "-"),
+  }),
   framework: "@storybook/react",
   core: {
     builder: "@storybook/builder-webpack5",

--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const alias = require("../config/alias");
-const getBranchName = require("./branch");
+const { getBranchName, getChromaticBranchName } = require("./branch");
 
 module.exports = {
   features: {
@@ -33,9 +33,8 @@ module.exports = {
     BRANCH_NAME: process.env.BRANCH_NAME ?? getBranchName(),
     CHROMATIC_APP_ID:
       process.env.CHROMATIC_APP_ID ?? "62d7d1f2efc8a1e364b5e5e8",
-    CHROMATIC_BRANCH_NAME: (process.env.BRANCH_NAME ?? getBranchName())
-      ?.toLowerCase()
-      .replace("/g", "-"),
+    CHROMATIC_BRANCH_NAME:
+      process.env.CHROMATIC_BRANCH_NAME ?? getChromaticBranchName(),
   }),
   framework: "@storybook/react",
   core: {

--- a/packages/design-system/build-storybook.log
+++ b/packages/design-system/build-storybook.log
@@ -1,0 +1,362 @@
+$ build-storybook --output-dir /var/folders/61/069rp0j513dbf05bknfnckyw0000gn/T/chromatic--31491-xvzRTTNkx3Ib
+info @storybook/react v6.4.22
+info 
+info => Cleaning outputDir: /var/folders/61/069rp0j513dbf05bknfnckyw0000gn/T/chromatic--31491-xvzRTTNkx3Ib
+info => Loading presets
+info => Loading custom manager config
+info => Compiling manager..
+info => Compiling preview..
+info => Loading custom manager config
+info => Using implicit CSS loaders
+info => Using default Webpack5 setup
+<s> [webpack.Progress] 0% 
+
+<s> [webpack.Progress] 1% setup initialize
+<s> [webpack.Progress] 1% setup initialize HtmlWebpackPlugin
+<s> [webpack.Progress] 1% setup initialize
+<s> [webpack.Progress] 2% setup before run
+<s> [webpack.Progress] 2% setup before run NodeEnvironmentPlugin
+<s> [webpack.Progress] 2% setup before run
+<s> [webpack.Progress] 3% setup run
+<s> [webpack.Progress] 3% setup run
+<s> [webpack.Progress] 4% setup normal module factory
+<s> [webpack.Progress] 4% setup normal module factory CaseSensitivePathsPlugin
+<s> [webpack.Progress] 4% setup normal module factory
+<s> [webpack.Progress] 5% setup context module factory
+<s> [webpack.Progress] 5% setup context module factory
+<s> [webpack.Progress] 6% setup before compile
+<s> [webpack.Progress] 6% setup before compile ProgressPlugin
+<s> [webpack.Progress] 6% setup before compile
+<s> [webpack.Progress] 7% setup compile
+<s> [webpack.Progress] 7% setup compile ExternalsPlugin
+<s> [webpack.Progress] 7% setup compile
+<s> [webpack.Progress] 8% setup compilation
+<s> [webpack.Progress] 8% setup compilation ArrayPushCallbackChunkFormatPlugin
+<s> [webpack.Progress] 8% setup compilation JsonpChunkLoadingPlugin
+<s> [webpack.Progress] 8% setup compilation StartupChunkDependenciesPlugin
+<s> [webpack.Progress] 8% setup compilation ImportScriptsChunkLoadingPlugin
+<s> [webpack.Progress] 8% setup compilation FetchCompileWasmPlugin
+<s> [webpack.Progress] 8% setup compilation FetchCompileAsyncWasmPlugin
+<s> [webpack.Progress] 8% setup compilation WorkerPlugin
+<s> [webpack.Progress] 8% setup compilation SplitChunksPlugin
+<s> [webpack.Progress] 8% setup compilation RuntimeChunkPlugin
+<s> [webpack.Progress] 8% setup compilation ResolverCachePlugin
+<s> [webpack.Progress] 8% setup compilation HtmlWebpackPlugin
+<s> [webpack.Progress] 8% setup compilation
+<s> [webpack.Progress] 9% setup compilation
+<s> [webpack.Progress] 9% setup compilation DefinePlugin
+<s> [webpack.Progress] 9% setup compilation ProvidePlugin
+<s> [webpack.Progress] 9% setup compilation ProgressPlugin
+<s> [webpack.Progress] 9% setup compilation DocGenPlugin
+<s> [webpack.Progress] 9% setup compilation ChunkPrefetchPreloadPlugin
+<s> [webpack.Progress] 9% setup compilation SourceMapDevToolPlugin
+<s> [webpack.Progress] 9% setup compilation JavascriptModulesPlugin
+<s> [webpack.Progress] 9% setup compilation JsonModulesPlugin
+<s> [webpack.Progress] 9% setup compilation AssetModulesPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation RuntimePlugin
+<s> [webpack.Progress] 9% setup compilation InferAsyncModulesPlugin
+<s> [webpack.Progress] 9% setup compilation DataUriPlugin
+<s> [webpack.Progress] 9% setup compilation FileUriPlugin
+<s> [webpack.Progress] 9% setup compilation CompatibilityPlugin
+<s> [webpack.Progress] 9% setup compilation HarmonyModulesPlugin
+<s> [webpack.Progress] 9% setup compilation AMDPlugin
+<s> [webpack.Progress] 9% setup compilation RequireJsStuffPlugin
+<s> [webpack.Progress] 9% setup compilation CommonJsPlugin
+<s> [webpack.Progress] 9% setup compilation LoaderPlugin
+<s> [webpack.Progress] 9% setup compilation LoaderPlugin
+<s> [webpack.Progress] 9% setup compilation NodeStuffPlugin
+<s> [webpack.Progress] 9% setup compilation APIPlugin
+<s> [webpack.Progress] 9% setup compilation ExportsInfoApiPlugin
+<s> [webpack.Progress] 9% setup compilation WebpackIsIncludedPlugin
+<s> [webpack.Progress] 9% setup compilation ConstPlugin
+<s> [webpack.Progress] 9% setup compilation UseStrictPlugin
+<s> [webpack.Progress] 9% setup compilation RequireIncludePlugin
+<s> [webpack.Progress] 9% setup compilation RequireEnsurePlugin
+<s> [webpack.Progress] 9% setup compilation RequireContextPlugin
+<s> [webpack.Progress] 9% setup compilation ImportPlugin
+<s> [webpack.Progress] 9% setup compilation SystemPlugin
+<s> [webpack.Progress] 9% setup compilation ImportMetaPlugin
+<s> [webpack.Progress] 9% setup compilation URLPlugin
+<s> [webpack.Progress] 9% setup compilation DefaultStatsFactoryPlugin
+<s> [webpack.Progress] 9% setup compilation DefaultStatsPresetPlugin
+<s> [webpack.Progress] 9% setup compilation DefaultStatsPrinterPlugin
+<s> [webpack.Progress] 9% setup compilation JavascriptMetaInfoPlugin
+<s> [webpack.Progress] 9% setup compilation EnsureChunkConditionsPlugin
+<s> [webpack.Progress] 9% setup compilation RemoveEmptyChunksPlugin
+<s> [webpack.Progress] 9% setup compilation MergeDuplicateChunksPlugin
+<s> [webpack.Progress] 9% setup compilation FlagIncludedChunksPlugin
+<s> [webpack.Progress] 9% setup compilation SideEffectsFlagPlugin
+<s> [webpack.Progress] 9% setup compilation FlagDependencyExportsPlugin
+<s> [webpack.Progress] 9% setup compilation FlagDependencyUsagePlugin
+<s> [webpack.Progress] 9% setup compilation InnerGraphPlugin
+<s> [webpack.Progress] 9% setup compilation MangleExportsPlugin
+<s> [webpack.Progress] 9% setup compilation ModuleConcatenationPlugin
+<s> [webpack.Progress] 9% setup compilation NoEmitOnErrorsPlugin
+<s> [webpack.Progress] 9% setup compilation RealContentHashPlugin
+<s> [webpack.Progress] 9% setup compilation WasmFinalizeExportsPlugin
+<s> [webpack.Progress] 9% setup compilation NamedModuleIdsPlugin
+<s> [webpack.Progress] 9% setup compilation DeterministicChunkIdsPlugin
+<s> [webpack.Progress] 9% setup compilation DefinePlugin
+<s> [webpack.Progress] 9% setup compilation TerserPlugin
+<s> [webpack.Progress] 9% setup compilation TemplatedPathPlugin
+<s> [webpack.Progress] 9% setup compilation RecordIdsPlugin
+<s> [webpack.Progress] 9% setup compilation WarnCaseSensitiveModulesPlugin
+<s> [webpack.Progress] 9% setup compilation IgnoreWarningsPlugin
+<s> [webpack.Progress] 9% setup compilation
+<s> [webpack.Progress] 10% building
+<s> [webpack.Progress] 10% building 0/1 entries 0/0 dependencies 0/0 modules
+<s> [webpack.Progress] 10% building import loader ./node_modules/@storybook/builder-webpack5/node_modules/babel-loader/lib/index.js
+<s> [webpack.Progress] 10% building 0/16 entries 3/16 dependencies 0/3 modules
+<s> [webpack.Progress] 10% building 0/16 entries 21/67 dependencies 0/19 modules
+<s> [webpack.Progress] 10% building import loader ../../node_modules/@storybook/source-loader/dist/cjs/index.js
+<s> [webpack.Progress] 10% building 0/16 entries 47/121 dependencies 2/44 modules
+<s> [webpack.Progress] 10% building 0/16 entries 400/637 dependencies 6/191 modules
+<s> [webpack.Progress] 10% building 0/16 entries 1254/1400 dependencies 78/369 modules
+<s> [webpack.Progress] 13% building 1/16 entries 1263/1649 dependencies 86/369 modules
+<s> [webpack.Progress] 13% building 1/16 entries 1729/1800 dependencies 179/507 modules
+<s> [webpack.Progress] 13% building 1/16 entries 2342/2400 dependencies 256/793 modules
+<s> [webpack.Progress] 13% building import loader ./node_modules/@storybook/builder-webpack5/node_modules/style-loader/dist/cjs.js
+<s> [webpack.Progress] 13% building import loader ./node_modules/@storybook/builder-webpack5/node_modules/css-loader/dist/cjs.js
+<s> [webpack.Progress] 13% building 1/16 entries 2736/2807 dependencies 294/975 modules
+<s> [webpack.Progress] 14% building 1/16 entries 3374/3400 dependencies 374/1057 modules
+<s> [webpack.Progress] 14% building 1/16 entries 4000/4324 dependencies 409/1078 modules
+<s> [webpack.Progress] 14% building 1/16 entries 4277/4324 dependencies 409/1100 modules
+<s> [webpack.Progress] 14% building 1/16 entries 4900/4961 dependencies 423/1147 modules
+<s> [webpack.Progress] 14% building import loader ./node_modules/@storybook/core-common/node_modules/babel-loader/lib/index.js
+<s> [webpack.Progress] 14% building 1/16 entries 4932/4961 dependencies 423/1169 modules
+<s> [webpack.Progress] 15% building 1/16 entries 5200/5305 dependencies 484/1187 modules
+<s> [webpack.Progress] 15% building 1/16 entries 5700/5947 dependencies 540/1287 modules
+<s> [webpack.Progress] 17% building 1/16 entries 6353/6388 dependencies 712/1500 modules
+<s> [webpack.Progress] 19% building 1/16 entries 6994/7152 dependencies 900/1631 modules
+<s> [webpack.Progress] 22% building import loader ./node_modules/@storybook/builder-webpack4/node_modules/babel-loader/lib/index.js
+<s> [webpack.Progress] 22% building 1/16 entries 7850/7908 dependencies 1178/1800 modules
+<s> [webpack.Progress] 24% building 2/16 entries 7996/8093 dependencies 1282/1834 modules
+<s> [webpack.Progress] 24% building 3/16 entries 7996/8093 dependencies 1283/1834 modules
+<s> [webpack.Progress] 24% building 4/16 entries 7996/8093 dependencies 1284/1834 modules
+<s> [webpack.Progress] 27% building 5/16 entries 7996/8093 dependencies 1285/1834 modules
+<s> [webpack.Progress] 30% building 6/16 entries 7996/8093 dependencies 1286/1834 modules
+<s> [webpack.Progress] 34% building 7/16 entries 7996/8093 dependencies 1287/1834 modules
+<s> [webpack.Progress] 37% building 8/16 entries 7996/8093 dependencies 1288/1834 modules
+<s> [webpack.Progress] 40% building 9/16 entries 7996/8093 dependencies 1289/1834 modules
+<s> [webpack.Progress] 44% building 10/16 entries 7996/8093 dependencies 1290/1834 modules
+<s> [webpack.Progress] 44% building 10/16 entries 8300/8345 dependencies 1359/1921 modules
+<s> [webpack.Progress] 47% building 11/16 entries 8601/8638 dependencies 1806/2000 modules
+<s> [webpack.Progress] 51% building 12/16 entries 9036/9055 dependencies 2009/2081 modules
+<s> [webpack.Progress] 54% building 13/16 entries 9074/9091 dependencies 2062/2095 modules
+<s> [webpack.Progress] 54% building 13/16 entries 9094/9100 dependencies 2068/2098 modules
+<s> [webpack.Progress] 58% building 14/16 entries 9125/9125 dependencies 2091/2110 modules
+<s> [webpack.Progress] 61% building 15/16 entries 9127/9127 dependencies 2111/2111 modules
+<s> [webpack.Progress] 65% building 16/16 entries 9127/9127 dependencies 2111/2111 modules
+<s> [webpack.Progress] 65% building
+<s> [webpack.Progress] 69% building finish
+<s> [webpack.Progress] 69% building finish
+<s> [webpack.Progress] 70% sealing finish module graph
+<s> [webpack.Progress] 70% sealing finish module graph ResolverCachePlugin
+<s> [webpack.Progress] 70% sealing finish module graph InferAsyncModulesPlugin
+<s> [webpack.Progress] 70% sealing finish module graph FlagDependencyExportsPlugin
+<s> [webpack.Progress] 70% sealing finish module graph InnerGraphPlugin
+<s> [webpack.Progress] 70% sealing finish module graph WasmFinalizeExportsPlugin
+<s> [webpack.Progress] 70% sealing finish module graph
+<s> [webpack.Progress] 70% sealing plugins
+<s> [webpack.Progress] 70% sealing plugins DocGenPlugin
+<s> [webpack.Progress] 70% sealing plugins WarnCaseSensitiveModulesPlugin
+<s> [webpack.Progress] 70% sealing plugins
+<s> [webpack.Progress] 71% sealing dependencies optimization
+<s> [webpack.Progress] 71% sealing dependencies optimization SideEffectsFlagPlugin
+<s> [webpack.Progress] 71% sealing dependencies optimization FlagDependencyUsagePlugin
+<s> [webpack.Progress] 71% sealing dependencies optimization
+<s> [webpack.Progress] 71% sealing after dependencies optimization
+<s> [webpack.Progress] 71% sealing after dependencies optimization
+<s> [webpack.Progress] 72% sealing chunk graph
+<s> [webpack.Progress] 72% sealing chunk graph
+<s> [webpack.Progress] 73% sealing after chunk graph
+<s> [webpack.Progress] 73% sealing after chunk graph
+<s> [webpack.Progress] 73% sealing optimizing
+<s> [webpack.Progress] 73% sealing optimizing
+<s> [webpack.Progress] 74% sealing module optimization
+<s> [webpack.Progress] 74% sealing module optimization
+<s> [webpack.Progress] 75% sealing after module optimization
+<s> [webpack.Progress] 75% sealing after module optimization
+<s> [webpack.Progress] 75% sealing chunk optimization
+<s> [webpack.Progress] 75% sealing chunk optimization EnsureChunkConditionsPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization RemoveEmptyChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization MergeDuplicateChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization SplitChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization RemoveEmptyChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization
+<s> [webpack.Progress] 76% sealing after chunk optimization
+<s> [webpack.Progress] 76% sealing after chunk optimization
+<s> [webpack.Progress] 77% sealing module and chunk tree optimization
+<s> [webpack.Progress] 77% sealing module and chunk tree optimization PersistentChildCompilerSingletonPlugin
+<s> [webpack.Progress] 77% sealing module and chunk tree optimization
+<s> [webpack.Progress] 77% sealing after module and chunk tree optimization
+<s> [webpack.Progress] 77% sealing after module and chunk tree optimization
+<s> [webpack.Progress] 78% sealing chunk modules optimization
+<s> [webpack.Progress] 78% sealing chunk modules optimization ModuleConcatenationPlugin
+<s> [webpack.Progress] 78% sealing chunk modules optimization
+<s> [webpack.Progress] 78% sealing after chunk modules optimization
+<s> [webpack.Progress] 78% sealing after chunk modules optimization
+<s> [webpack.Progress] 79% sealing module reviving
+<s> [webpack.Progress] 79% sealing module reviving RecordIdsPlugin
+<s> [webpack.Progress] 79% sealing module reviving
+<s> [webpack.Progress] 80% sealing before module ids
+<s> [webpack.Progress] 80% sealing before module ids
+<s> [webpack.Progress] 80% sealing module ids
+<s> [webpack.Progress] 80% sealing module ids NamedModuleIdsPlugin
+<s> [webpack.Progress] 80% sealing module ids
+<s> [webpack.Progress] 81% sealing module id optimization
+<s> [webpack.Progress] 81% sealing module id optimization
+<s> [webpack.Progress] 82% sealing module id optimization
+<s> [webpack.Progress] 82% sealing module id optimization
+<s> [webpack.Progress] 82% sealing chunk reviving
+<s> [webpack.Progress] 82% sealing chunk reviving RecordIdsPlugin
+<s> [webpack.Progress] 82% sealing chunk reviving
+<s> [webpack.Progress] 83% sealing before chunk ids
+<s> [webpack.Progress] 83% sealing before chunk ids
+<s> [webpack.Progress] 84% sealing chunk ids
+<s> [webpack.Progress] 84% sealing chunk ids DeterministicChunkIdsPlugin
+<s> [webpack.Progress] 84% sealing chunk ids
+<s> [webpack.Progress] 84% sealing chunk id optimization
+<s> [webpack.Progress] 84% sealing chunk id optimization FlagIncludedChunksPlugin
+<s> [webpack.Progress] 84% sealing chunk id optimization
+<s> [webpack.Progress] 85% sealing after chunk id optimization
+<s> [webpack.Progress] 85% sealing after chunk id optimization
+<s> [webpack.Progress] 86% sealing record modules
+<s> [webpack.Progress] 86% sealing record modules RecordIdsPlugin
+<s> [webpack.Progress] 86% sealing record modules
+<s> [webpack.Progress] 86% sealing record chunks
+<s> [webpack.Progress] 86% sealing record chunks RecordIdsPlugin
+<s> [webpack.Progress] 86% sealing record chunks
+<s> [webpack.Progress] 87% sealing module hashing
+<s> [webpack.Progress] 87% sealing module hashing
+<s> [webpack.Progress] 87% sealing code generation
+<s> [webpack.Progress] 87% sealing code generation
+<s> [webpack.Progress] 88% sealing runtime requirements
+<s> [webpack.Progress] 88% sealing runtime requirements
+<s> [webpack.Progress] 89% sealing hashing
+<s> [webpack.Progress] 89% sealing hashing
+<s> [webpack.Progress] 89% sealing after hashing
+<s> [webpack.Progress] 89% sealing after hashing
+<s> [webpack.Progress] 90% sealing record hash
+<s> [webpack.Progress] 90% sealing record hash
+<s> [webpack.Progress] 91% sealing module assets processing
+<s> [webpack.Progress] 91% sealing module assets processing
+<s> [webpack.Progress] 91% sealing chunk assets processing
+<s> [webpack.Progress] 91% sealing chunk assets processing
+<s> [webpack.Progress] 92% sealing asset processing
+<s> [webpack.Progress] 92% sealing asset processing PersistentChildCompilerSingletonPlugin
+<s> [webpack.Progress] 92% sealing asset processing TerserPlugin
+info => Manager built (20 s)
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin main.83c5503e.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin main.83c5503e.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin runtime~main.cc9b8979.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin runtime~main.cc9b8979.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 701.2d8b4ee3.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 701.2d8b4ee3.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 985.f77927e9.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 985.f77927e9.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 172.583b625d.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 172.583b625d.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 994.69650a29.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 994.69650a29.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 135.fa865c5e.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 135.fa865c5e.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 531.7323becc.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 531.7323becc.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 887.2fbc055f.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 887.2fbc055f.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 681.c9bf1f67.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 681.c9bf1f67.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 681.c9bf1f67.iframe.bundle.js attach SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 681.c9bf1f67.iframe.bundle.js attached SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin main.4f47ce0a.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin main.4f47ce0a.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin runtime~main.3999197e.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin runtime~main.3999197e.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 701.f0750543.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 701.f0750543.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 985.fec88182.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 985.fec88182.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 994.ad9bccf8.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 994.ad9bccf8.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 135.2512a897.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 135.2512a897.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 531.23453cc0.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 531.23453cc0.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 172.498d87df.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 172.498d87df.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 887.70951df6.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 887.70951df6.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin
+<s> [webpack.Progress] 92% sealing asset processing
+<s> [webpack.Progress] 93% sealing after asset optimization
+<s> [webpack.Progress] 93% sealing after asset optimization
+<s> [webpack.Progress] 93% sealing recording
+<s> [webpack.Progress] 93% sealing recording
+<s> [webpack.Progress] 94% sealing after seal
+<s> [webpack.Progress] 94% sealing after seal
+<s> [webpack.Progress] 95% emitting emit
+<s> [webpack.Progress] 95% emitting emit
+<s> [webpack.Progress] 98% emitting after emit
+<s> [webpack.Progress] 98% emitting after emit SizeLimitsPlugin
+<s> [webpack.Progress] 98% emitting after emit
+<s> [webpack.Progress] 99% done plugins
+<s> [webpack.Progress] 99% done plugins CaseSensitivePathsPlugin
+<s> [webpack.Progress] 99% done plugins
+<s> [webpack.Progress] 99% 
+
+<s> [webpack.Progress] 99% cache store build dependencies
+<s> [webpack.Progress] 99% cache store build dependencies
+<s> [webpack.Progress] 99% cache begin idle
+<s> [webpack.Progress] 99% cache begin idle
+<s> [webpack.Progress] 100% 
+
+info => Preview built (23 s)
+WARN export 'hasOwnProperty' (imported as 'base') was not found in './base' (possible exports: blue, blueText, green, greenText, grey, greyText, lunitGreen, lunitGreenText, lunitTeal, lunitTealText, magenta, magentaText, orange, orangeText, red, redText, yellow, yellowText)
+WARN asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
+WARN This can impact web performance.
+WARN Assets: 
+WARN   985.fec88182.iframe.bundle.js (573 KiB)
+WARN   681.5cfd02ae.iframe.bundle.js (1.68 MiB)
+WARN entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
+WARN Entrypoints:
+WARN   main (1.73 MiB)
+WARN       runtime~main.3999197e.iframe.bundle.js
+WARN       681.5cfd02ae.iframe.bundle.js
+WARN       main.4f47ce0a.iframe.bundle.js
+WARN 
+<s> [webpack.Progress] 99% cache shutdown
+<s> [webpack.Progress] 99% cache shutdown
+<s> [webpack.Progress] 100% 
+
+info => Output directory: /var/folders/61/069rp0j513dbf05bknfnckyw0000gn/T/chromatic--31491-xvzRTTNkx3Ib

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -14,7 +14,8 @@
     "build": "webpack",
     "create:logo-files": "node ./create.logo.mjs && webpack --watch",
     "storybook": "node ./create.logo.mjs && start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "chromatic": "chromatic"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
@@ -35,6 +36,7 @@
     "@storybook/testing-library": "^0.0.11",
     "@storybook/theming": "^6.4.22",
     "babel-loader": "^8.2.5",
+    "chromatic": "^6.7.0",
     "mustache": "^4.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7228,6 +7228,11 @@
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.3.tgz#b776327a73e561b71e7881d0cd6d34a1424db86a"
   integrity sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw==
 
+"@types/webpack-env@^1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.17.0.tgz#f99ce359f1bfd87da90cc4a57cab0a18f34a48d0"
+  integrity sha512-eHSaNYEyxRA5IAG0Ym/yCyf86niZUIF/TpWKofQI/CVfh5HsMEUyfE2kwFxha4ow0s5g0LfISQxpDKjbRDrizw==
+
 "@types/webpack-sources@*":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
@@ -9153,6 +9158,13 @@ chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+chromatic@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-6.7.0.tgz#1d56c56acea6762d18c6042774fbfb6b434c6d91"
+  integrity sha512-kLpvVBKHp1uh7v14N0gPoejILsepS2OI8a4cJgM4Na0Du5GbZ0Iq7Yq/QknCuNiztlalSpBYHuD9SuVdBxL9vg==
+  dependencies:
+    "@types/webpack-env" "^1.17.0"
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
# Description
+ add chromatic to deploy Storybook
+ add permalink of published Storybook by branches

Chromatic에서 Branch별 Permalink를 확인할 수 없어서 
Build별 스토리북에 바로가기를 추가했습니다.

+ LDS-43-chromatic Branch의 **Permalink**: https://lds-43-chromatic--62d7d1f2efc8a1e364b5e5e8.chromatic.com
+ LDS-43-chromatic Branch의 **Build 11 Link**: https://62d7d1f2efc8a1e364b5e5e8-knwrzzozic.chromatic.com

<img width="729" alt="스크린샷 2022-07-30 오후 7 16 35" src="https://user-images.githubusercontent.com/83567940/181906060-484360dc-4bfd-4048-a866-35920cd91d7f.png">