### PR TITLE
feat(logo): support favicon path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 - [Design System Library](packages/design-system/)
 - [Design System Icons](packages/design-system-icons/)
+- [Design System Logo](packages/design-system-logo/)
 - [Mui Theme](packages/mui-theme/)
-

--- a/packages/design-system-logo/README.md
+++ b/packages/design-system-logo/README.md
@@ -12,12 +12,10 @@ This package provides logos used in the Lunit projects.
 Install the package in your project directory with:
 
 ```sh
-// with npm
-npm install @lunit/design-system-logo
-
-// with yarn
-yarn add @lunit/design-system-logo
+npx @lunit/design-system-logo --favicon-path=<path>
 ```
+
+If you want to save the favicon files, please set the path option.
 
 ## Usage
 
@@ -25,13 +23,13 @@ We recommend that you use path imports(**option 1**). It can avoid pulling in un
 
 ```tsx
 // option 1 size: 11.7k (gzipped: 4.6k)
-import Lunit from "@lunit/design-system-logo/Lunit"
+import Lunit from "@lunit/design-system-logo/Lunit";
 // option 2 size: 578.1k (gzipped: 87.1k)
-import { Lunit } from "@lunit/design-system-logo"
+import { Lunit } from "@lunit/design-system-logo";
 
 const Logo = () => (
   <Lunit style={{ height: "20px" }} /> // only svg file
-)
+);
 
 export default Logo;
 ```

--- a/packages/design-system-logo/favicon.mjs
+++ b/packages/design-system-logo/favicon.mjs
@@ -1,0 +1,156 @@
+#! /usr/bin/env node
+import fse from "fs-extra";
+import https from "https";
+import chalk from "chalk";
+import semver from "semver";
+import { Command } from "commander";
+import { execSync } from "child_process";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const currentPath = process.cwd();
+const filePath = path.join(__dirname, "favicon");
+
+function getLatestVersion() {
+  return new Promise((resolve, reject) => {
+    https
+      .get(
+        "https://registry.npmjs.org/-/package/@lunit/design-system-logo/dist-tags",
+        (res) => {
+          if (res.statusCode === 200) {
+            let body = "";
+            res.on("data", (data) => (body += data));
+            res.on("end", () => {
+              resolve(JSON.parse(body).latest);
+            });
+          } else {
+            reject();
+          }
+        }
+      )
+      .on("error", (err) => {
+        console.log();
+        console.error(
+          "Unable to get the latest version information: ",
+          chalk.yellow(err)
+        );
+        console.log();
+        process.exit(1);
+      });
+  });
+}
+
+async function moveToFavicon(faviconPath) {
+  if (!fse.existsSync(faviconPath)) {
+    await fse.mkdir(faviconPath);
+  }
+
+  if (!fse.existsSync(filePath)) {
+    console.log();
+    console.error(chalk.yellow("The favicon files don't exist."));
+    console.log();
+    return;
+  }
+
+  fse.readdir(filePath, (err, files) => {
+    if (err) {
+      console.log();
+      console.error(chalk.yellow(err));
+      console.log();
+      return;
+    }
+
+    // move favicon files
+    files.forEach((file) => {
+      fse.rename(path.join(filePath, file), path.join(faviconPath, file));
+    });
+
+    console.log();
+    console.log(chalk.green("success"), "Saved the favicon");
+    console.log();
+    console.log(
+      chalk.blue("Info "),
+      "See README.md for favicon settings: https://github.com/lunit-io/design-system/tree/main/packages/design-system-logo#favicon"
+    );
+    console.log();
+  });
+}
+
+function installPackage(option) {
+  let packageManager = option;
+  if (!packageManager) {
+    if (fse.existsSync(path.join(currentPath, "yarn.lock"))) {
+      packageManager = "yarn";
+    }
+    if (fse.existsSync(path.join(currentPath, "package-lock.json"))) {
+      packageManager = "npm";
+    }
+
+    if (packageManager !== "yarn" && packageManager !== "npm") {
+      console.log();
+      console.error(
+        chalk.yellow(
+          "Unable to determine package manager type. Please set the options."
+        )
+      );
+      console.log();
+    }
+  }
+
+  console.log();
+  console.log(`Installing ${chalk.cyan("@lunit/design-system-logo")}...`);
+  console.log();
+  if (packageManager === "yarn") {
+    execSync("yarn add @lunit/design-system-logo", { stdio: "inherit" });
+  }
+  if (packageManager === "npm") {
+    execSync("npm install @lunit/design-system-logo", { stdio: "inherit" });
+  }
+}
+
+async function init() {
+  const packageJson = JSON.parse(
+    await fse.readFile(path.join(__dirname, "package.json"), {
+      encoding: "utf8",
+    })
+  );
+
+  const program = new Command(packageJson.name)
+    .version(packageJson.version)
+    .option("--favicon-path <path>", "Path to save the favicon")
+    .option("--package-manager <type>", "Please set either yarn or npm");
+
+  const options = program.opts();
+  const latest = await getLatestVersion();
+
+  program.parse(process.argv);
+
+  if (latest && semver.lt(packageJson.version, latest)) {
+    console.log();
+    console.error(
+      chalk.yellow(
+        `You are running \`@lunit/design-system-logo\` ${packageJson.version}, which is behind the latest release (${latest}).\n\n` +
+          "We recommend always using the latest version of @lunit/design-system-logo if possible."
+      )
+    );
+    console.log();
+    process.exit(1);
+  }
+
+  installPackage(options.packageManager);
+
+  if (options.faviconPath) {
+    const faviconPath = path.join(currentPath, options.faviconPath);
+    moveToFavicon(faviconPath);
+  } else {
+    console.log();
+    console.log(
+      chalk.blue("Info"),
+      "If you want to install favicon, please set the path option."
+    );
+    console.log();
+  }
+}
+
+init();

--- a/packages/design-system-logo/package.json
+++ b/packages/design-system-logo/package.json
@@ -16,12 +16,18 @@
     "postinstall": "node ./postinstall.favicon.mjs",
     "dev": "node ./generator.mjs && webpack --watch",
     "build": "node ./generator.mjs && webpack",
-    "postbuild": "cp package.json README.md postinstall.favicon.mjs dist && cp -r ./src/assets/favicon dist",
+    "postbuild": "cp package.json README.md favicon.mjs postinstall.favicon.mjs dist && cp -r ./src/assets/favicon dist",
     "prepublishOnly": "[[ \"$PWD\" == *dist ]] || { exit 1; }",
     "storybook": "yarn build && start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
-  "dependencies": {},
+  "bin": "./favicon.mjs",
+  "dependencies": {
+    "chalk": "^5.0.1",
+    "commander": "^9.4.0",
+    "fs-extra": "^10.1.0",
+    "semver": "^7.3.7"
+  },
   "devDependencies": {
     "@babel/core": "^7.18.10",
     "@storybook/addon-actions": "^6.5.10",

--- a/packages/design-system-logo/package.json
+++ b/packages/design-system-logo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/design-system-logo",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Lunit Design System Logo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/design-system-logo/postinstall.favicon.mjs
+++ b/packages/design-system-logo/postinstall.favicon.mjs
@@ -3,38 +3,7 @@ import path, { dirname } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootPath = __dirname.split("node_modules")[0];
 const faviconPath = path.join(__dirname, "favicon");
-const publicPath = path.join(rootPath, "public");
-
-async function handler() {
-  // check path exist
-  if (!fse.existsSync(publicPath)) {
-    console.log(
-      "The favicon files aren't saved because the public directory doesn't exist."
-    );
-    return;
-  }
-
-  if (!fse.existsSync(faviconPath)) {
-    console.log("The favicon directory doesn't exist.");
-    return;
-  }
-
-  fse.readdir(faviconPath, (err, files) => {
-    if (err) {
-      console.log(err);
-      return;
-    }
-
-    // move favicon files
-    files.forEach((file) => {
-      fse.rename(path.join(faviconPath, file), path.join(publicPath, file));
-    });
-  });
-}
-
-handler();
 
 // remove favicon directory
 if (fse.existsSync(faviconPath)) {


### PR DESCRIPTION
# Description

* .bin 파일을 통해 npx 지원
* npx로 설치시 최신버전인지 확인합니다. 최신버전이 아닐시 실행이 종료되고 에러메시지가 표시됩니다.
* 설치하는 프로젝트에서 lock file을 확인하여 yarn과 npm을 확인합니다. 혹은 `--package-manager`으로 option (npm / yarn)을 설정할 수 있습니다. 확인 후 logo package를 설치합니다. 
* npx로 설치된 위치에서 favicon 파일을 프로젝트 폴더로 옮깁니다. 
* --favicon-path을 설정하지 않았을 시 logo 패키지만 설치 됩니다. 
* postinstall시 node module에 설치된 favicon 파일이 삭제됩니다. 
* npx 실행을 위한 패키지는 dependencies에 정의해야 정상적으로 실행됩니다. 

## Test

build 파일을 생성합니다. 생성된 build 폴더안에서 install을 합니다. 
```sh
npm exec -- <dist-path> --favicon-path=<path>
```
로 테스트 가능합니다. 

참고 
https://docs.npmjs.com/cli/v8/commands/npx#:~:text=The%20following%20command%20would%20thus%20be%20equivalent%20to%20the%20npx%20command%20above%3A
https://github.com/facebook/create-react-app/blob/main/packages/create-react-app/createReactApp.js