### PR TITLE
fix(logo): install error message

### DIFF
--- a/packages/design-system-logo/favicon.mjs
+++ b/packages/design-system-logo/favicon.mjs
@@ -95,6 +95,7 @@ function installPackage(option) {
         )
       );
       console.log();
+      return;
     }
   }
 

--- a/packages/design-system-logo/package.json
+++ b/packages/design-system-logo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/design-system-logo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Lunit Design System Logo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Description 

install시 npm으로 설치할지 yarn으로 설치할 지 정하지 못한 경우에 나온 에러메시지가  
install 진행중 이라는 메시지가 같이 노출되어 수정되었습니다. 

AS-IS 
Unable to determine package manager type. Please set the options.

Installing @lunit/design-system-logo...

TO-BE
Unable to determine package manager type. Please set the options.