### PR TITLE
fix(logo): invalid bin entry warning

### DIFF
--- a/packages/design-system-logo/package.json
+++ b/packages/design-system-logo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/design-system-logo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Lunit Design System Logo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -20,9 +20,7 @@
     "storybook": "yarn build && start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
-  "bin": {
-    "@lunit/design-system-logo": "./favicon.mjs"
-  },
+  "bin": "./favicon.mjs",
   "dependencies": {
     "chalk": "^5.0.1",
     "commander": "^9.4.0",


### PR DESCRIPTION
## Description 

> warning @lunit/design-system-logo@1.0.1: Invalid bin entry for "@lunit/design-system-logo" (in "@lunit/design-system-logo").

warning 메시지를 해결하기위해 수정합니다. 

```json
  "bin": {
    "@lunit/design-system-logo": "./favicon.mjs"
  },
```
@나 / 가 원인으로 생각되어 동일하게 실행될 수 있는 `"bin": "./favicon.mjs",` 으로 수정하였습니다. 
@lunit/design-system-logo@1.0.1-beta.1 를 릴리즈하여 확인하였습니다. 