### PR TITLE
chore(icons): add sub-paths to exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Lunit Design System
 
+## Setup
+
+This repository uses [lerna](https://lerna.js.org). You should install lerna by running this command:
+
+`npx lerna bootstrap --use-workspaces`
+
+## Packages
+
 - [Design System Library](packages/design-system/)
 - [Design System Icons](packages/design-system-icons/)
 - [Design System Logo](packages/design-system-logo/)

--- a/packages/design-system-icons/.npmignore
+++ b/packages/design-system-icons/.npmignore
@@ -1,0 +1,2 @@
+generated
+storybook-static

--- a/packages/design-system-icons/package.json
+++ b/packages/design-system-icons/package.json
@@ -1,9 +1,27 @@
 {
   "name": "@lunit/design-system-icons",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Icons for Lunit design system",
-  "main": "index.js",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*/index.d.ts",
+      "default": "./dist/*/index.js"
+    }
+  },
+  "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*/index.d.ts",
+        "dist/index.d.ts"
+      ]
+    }
+  },
   "license": "UNLICENSED",
   "repository": {
     "type": "git",
@@ -15,8 +33,6 @@
     "test": "jest",
     "dev": "node ./builder.mjs && webpack --watch & yarn storybook",
     "build": "node ./builder.mjs && webpack",
-    "postbuild": "cp package.json README.md dist",
-    "prepublishOnly": "[[ \"$PWD\" == *dist ]] || { exit 1; }",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook --docs && npx -y storybook extract "
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10318,6 +10318,11 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.0.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.1.2.tgz#d957f370038b75ac572471e83be4c5ca9f8e8c45"
+  integrity sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -10696,6 +10701,11 @@ commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+
+commander@^9.4.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 common-path-prefix@^3.0.0:
   version "3.0.0"
@@ -19773,6 +19783,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.2:
   version "0.17.2"


### PR DESCRIPTION
#50 에서 발견된 모노레포 내에서 이 패키지 참조가 불가능한 문제를 해결합니다.

기존에는 sub-path에 있는 모듈을 import 시 자연스럽게 resolve 할 수 있도록 다음과 같은 방식을 사용했습니다.

1. dist 안에 빌드 결과물인 index와 각 컴포넌트 폴더를 생성
2. package.json을 dist 안으로 이동
3. package.json에서는 같은 dist 폴더 안에 빌드 결과물이 있다고 가정하고 `main`, `types` 필드 등을 설정

그러나 이 방법으로는 이동 전의 package.json에서는 컴포넌트를 참조할 수 없는 문제가 있고, 배포도 번거로웠습니다.
그래서 [exports](https://webpack.kr/guides/package-exports/)와 [typesVersions](https://github.com/andrewbranch/example-subpath-exports-ts-compat)를 이용하여 sub-path에서 모듈을 찾을 수 있도록 설정하였습니다.

