### PR TITLE
Feature/build monorepo

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,7 +7,8 @@ env:
 # Event for the workflow
 on:
   push:
-    branch: main
+    branches:
+      - "main"
     paths:
       - ".github/workflows/chromatic.yml"
       - "packages/design-system/**"
@@ -36,14 +37,14 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         id: branch-name
         run: |
-          echo "::set-output name=value::$(echo $BRANCH_NAME)"
+          echo "value=$(echo $BRANCH_NAME)" >> $GITHUB_OUTPUT
 
       - name: Get Chromatic branch name
         env:
           BRANCH_NAME: ${{ steps.branch-name.outputs.value }}
         id: chromatic-branch-name
         run: |
-          echo "::set-output name=value::$(echo $BRANCH_NAME | tr '[:upper:]' '[:lower:]' | tr / -)"
+          echo "value=$(echo $BRANCH_NAME | tr '[:upper:]' '[:lower:]' | tr / -)" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         run: npx lerna bootstrap --ci --use-workspaces
@@ -65,7 +66,7 @@ jobs:
         env:
           CHROMATIC_BRANCH_NAME: ${{ steps.chromatic-branch-name.outputs.value }}
         if: ${{ github.event_name == 'pull_request' }}
-        uses: NejcZdovc/comment-pr@v1.1.1
+        uses: NejcZdovc/comment-pr@v2.0.0
         with:
           message: "preview: https://${{ env.CHROMATIC_BRANCH_NAME }}--${{ env.CHROMATIC_APP_ID }}.chromatic.com"
           identifier: "PREVIEW_LINK_COMMENT"

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,29 +1,35 @@
 # Workflow name
-name: "Chromatic Deployment"
+name: "Chromatic Deployment - Design System"
 
 env:
   CHROMATIC_APP_ID: 62d7d1f2efc8a1e364b5e5e8
 
 # Event for the workflow
-on: 
+on:
   push:
-    paths-ignore:
-      - '.storybook/Welcome/**'
-  pull_request: 
-    paths-ignore:
-      - '.storybook/Welcome/**'
+    branch: main
+    paths:
+      - ".github/workflows/chromatic.yml"
+      - "packages/design-system/**"
+      - "packages/design-system-icons/**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/chromatic.yml"
+      - "packages/design-system/**"
+      - "packages/design-system-icons/**"
 
 # List of jobs
 jobs:
   deploy-staging:
     # Operating System
     runs-on: ubuntu-latest
-    env:
-      WORKDIR: ./packages/design-system
     # Job steps
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to retrieve git history
 
       - name: Get branch name
         env:
@@ -40,21 +46,20 @@ jobs:
           echo "::set-output name=value::$(echo $BRANCH_NAME | tr '[:upper:]' '[:lower:]' | tr / -)"
 
       - name: Install dependencies
-        if: ${{ github.event_name == 'push' }}
-        run: yarn
-        working-directory: ${{ env.WORKDIR }}
+        run: npx lerna bootstrap --ci --use-workspaces
+
+      - name: Build design-system package and its dependencies
+        run: yarn build:design-system
 
       - name: Publish to Chromatic
         env:
           BRANCH_NAME: ${{ steps.branch-name.outputs.value }}
           CHROMATIC_BRANCH_NAME: ${{ steps.chromatic-branch-name.outputs.value }}
         id: chromatic
-        if: ${{ github.event_name == 'push' }}
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          workingDir: ${{ env.WORKDIR }}
+          workingDir: packages/design-system
 
       - name: Comment preview link
         env:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "docs"
   ],
   "scripts": {
-    "build:mui-theme": "lerna run --scope @lunit/mui-theme build"
+    "build:mui-theme": "lerna run --scope @lunit/mui-theme build",
+    "build:design-system": "lerna run --scope @lunit/design-system --include-dependencies build"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -45,7 +45,9 @@
     "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@lunit/design-system-icons": "*"
+  },
   "peerDependencies": {
     "@mui/material": "^5.0.0",
     "react": ">=17",


### PR DESCRIPTION
## Summary

`@lunit/design-system`에서 `@lunit/design-system-icons` 의존성을 가지게 됨에 따라, 레포지터리 루트에서 lerna를 이용해 의존성과 함께 빌드하도록 변경하고 이에 맞게 Chromatic 배포도 변경하였습니다.

- `lerna run --scope @lunit/design-system --include-dependencies build` 명령은 `design-system` 패키지의 의존성 패키지를 포함하여 `build` 명령을 실행합니다. 의존성은 `packages/design-system/package.json`에 `"@lunit/design-system-icons": "*"`으로 명시되어 있습니다.
- `chromaui/action@v1` 액션은 위의 빌드 명령을 실행한 후 이전과 동일하게 `packages/design-system` 안에서 스토리북 빌드와 배포를 진행합니다.
- PR과 Push 모두에서 불필요하게 액션이 수행되던 조건을 수정하여 모든 PR과 `main` Push에 대해서만 액션을 수행합니다.
