### PR TITLE
[LDS-9] refactor custom chip component

### DIFF
--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -108,8 +108,8 @@ export const StyledContainedChip = styled(MuiChip, {
     alignItems: "center",
     // TODO: Currently, the color names of Figma and Design system's color component's name don't match
     // Need to be Fixed after the color system is completed
-    color: getColorToken("text", theme, color),
-    backgroundColor: getColorToken("bg", theme, color),
+    color: getColorToken("bg", theme, color),
+    backgroundColor: getColorToken("text", theme, color),
   },
 
   "& .MuiChip-deleteIcon": {

--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -1,57 +1,90 @@
 import { Chip as MuiChip, styled } from "@mui/material";
-import { CHIP_COLORS, COMMON_STYLES } from "./consts";
+import { CHIP_COLORS } from "./consts";
 
-import type { ChipProps } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
+import type {
+  ChipColor,
+  OutlinedChipProps,
+  BaseContainedChipProps,
+} from "./Chip.types";
+
+const COMMON_STYLES = {
+  "&.MuiChip-root": {
+    height: "22px",
+    width: "auto",
+    minWidth: "22px",
+  },
+  "&.Mui-disabled": {
+    opacity: 1,
+  },
+  "& .MuiChip-label": {
+    height: "16px",
+    fontStyle: "normal",
+    fontWeight: 500,
+    fontSize: "12px",
+    lineHeight: "16px",
+    display: "flex",
+    alignItems: "center",
+    textAlign: "center",
+    padding: 0,
+    marginInline: "8px",
+  },
+};
+
+const getColorToken = (
+  token: "text" | "bg",
+  theme: Theme,
+  color?: ChipColor
+) => {
+  if (token === "text") {
+    switch (color) {
+      case CHIP_COLORS.PRIMARY:
+        return theme.palette.token.component.chip_primary_text;
+      case CHIP_COLORS.SECONDARY:
+        return theme.palette.token.component.chip_secondary_text;
+      case CHIP_COLORS.ERROR:
+        return theme.palette.token.component.chip_error_text;
+      case CHIP_COLORS.WARNING:
+        return theme.palette.token.component.chip_warning_text;
+      case CHIP_COLORS.SUCCESS:
+        return theme.palette.token.component.chip_success_text;
+      default:
+        return theme.palette.token.component.chip_primary_text;
+    }
+  } else {
+    switch (color) {
+      case CHIP_COLORS.PRIMARY:
+        return theme.palette.token.component.chip_primary_bg;
+      case CHIP_COLORS.SECONDARY:
+        return theme.palette.token.component.chip_secondary_bg;
+      case CHIP_COLORS.ERROR:
+        return theme.palette.token.component.chip_error_bg;
+      case CHIP_COLORS.WARNING:
+        return theme.palette.token.component.chip_warning_bg;
+      case CHIP_COLORS.SUCCESS:
+        return theme.palette.token.component.chip_success_bg;
+      default:
+        return theme.palette.token.component.chip_primary_bg;
+    }
+  }
+};
 
 export const StyledOutlinedChip = styled(MuiChip, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<ChipProps>(({ theme, color }) => ({
+})<OutlinedChipProps>(({ theme, color }) => ({
   ...COMMON_STYLES,
 
-  color:
-    color === CHIP_COLORS.PRIMARY
-      ? theme.palette.token.component.chip_primary_text
-      : color === CHIP_COLORS.SECONDARY
-      ? theme.palette.token.component.chip_secondary_text
-      : color === CHIP_COLORS.ERROR
-      ? theme.palette.token.component.chip_error_text
-      : color === CHIP_COLORS.WARNING
-      ? theme.palette.token.component.chip_warning_text
-      : color === CHIP_COLORS.SUCCESS
-      ? theme.palette.token.component.chip_success_text
-      : theme.palette.token.component.chip_primary_text,
-  borderColor:
-    color === CHIP_COLORS.PRIMARY
-      ? theme.palette.token.component.chip_primary_text
-      : color === CHIP_COLORS.SECONDARY
-      ? theme.palette.token.component.chip_secondary_text
-      : color === CHIP_COLORS.ERROR
-      ? theme.palette.token.component.chip_error_text
-      : color === CHIP_COLORS.WARNING
-      ? theme.palette.token.component.chip_warning_text
-      : color === CHIP_COLORS.SUCCESS
-      ? theme.palette.token.component.chip_success_text
-      : theme.palette.token.component.chip_primary_text,
+  color: getColorToken("text", theme, color),
+  borderColor: getColorToken("bg", theme, color),
 }));
 
 export const StyledContainedChip = styled(MuiChip, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<ChipProps>(() => ({ theme, color }) => ({
+})<BaseContainedChipProps>(() => ({ theme, color }) => ({
   ...COMMON_STYLES,
 
   color: theme.palette.token.core.text_normal,
-  backgroundColor:
-    color === CHIP_COLORS.PRIMARY
-      ? theme.palette.token.component.chip_primary_bg
-      : color === CHIP_COLORS.SECONDARY
-      ? theme.palette.token.component.chip_secondary_bg
-      : color === CHIP_COLORS.ERROR
-      ? theme.palette.token.component.chip_error_bg
-      : color === CHIP_COLORS.WARNING
-      ? theme.palette.token.component.chip_warning_bg
-      : color === CHIP_COLORS.SUCCESS
-      ? theme.palette.token.component.chip_success_bg
-      : theme.palette.token.component.chip_primary_bg,
+  backgroundColor: getColorToken("bg", theme, color),
 
   "& .MuiSvgIcon-root": {
     marginBlock: "3px",
@@ -59,18 +92,7 @@ export const StyledContainedChip = styled(MuiChip, {
     marginRight: "4px",
     height: "16px",
     width: "16px",
-    color:
-      color === CHIP_COLORS.PRIMARY
-        ? theme.palette.token.component.chip_primary_text
-        : color === CHIP_COLORS.SECONDARY
-        ? theme.palette.token.component.chip_secondary_text
-        : color === CHIP_COLORS.ERROR
-        ? theme.palette.token.component.chip_error_text
-        : color === CHIP_COLORS.WARNING
-        ? theme.palette.token.component.chip_warning_text
-        : color === CHIP_COLORS.SUCCESS
-        ? theme.palette.token.component.chip_success_text
-        : theme.palette.token.component.chip_primary_text,
+    color: getColorToken("text", theme, color),
   },
   "& .MuiChip-avatar": {
     marginBlock: "3px",
@@ -86,30 +108,8 @@ export const StyledContainedChip = styled(MuiChip, {
     alignItems: "center",
     // TODO: Currently, the color names of Figma and Design system's color component's name don't match
     // Need to be Fixed after the color system is completed
-    color:
-      color === CHIP_COLORS.PRIMARY
-        ? theme.palette.token.component.chip_primary_bg
-        : color === CHIP_COLORS.SECONDARY
-        ? theme.palette.token.component.chip_secondary_bg
-        : color === CHIP_COLORS.ERROR
-        ? theme.palette.token.component.chip_error_bg
-        : color === CHIP_COLORS.WARNING
-        ? theme.palette.token.component.chip_warning_bg
-        : color === CHIP_COLORS.SUCCESS
-        ? theme.palette.token.component.chip_success_bg
-        : theme.palette.token.component.chip_primary_bg,
-    backgroundColor:
-      color === CHIP_COLORS.PRIMARY
-        ? theme.palette.token.component.chip_primary_text
-        : color === CHIP_COLORS.SECONDARY
-        ? theme.palette.token.component.chip_secondary_text
-        : color === CHIP_COLORS.ERROR
-        ? theme.palette.token.component.chip_error_text
-        : color === CHIP_COLORS.WARNING
-        ? theme.palette.token.component.chip_warning_text
-        : color === CHIP_COLORS.SUCCESS
-        ? theme.palette.token.component.chip_success_text
-        : theme.palette.token.component.chip_primary_text,
+    color: getColorToken("text", theme, color),
+    backgroundColor: getColorToken("bg", theme, color),
   },
 
   "& .MuiChip-deleteIcon": {

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Avatar } from "@mui/material";
 import { Close16 } from "@lunit/design-system-icons";
 import { StyledOutlinedChip, StyledContainedChip } from "./Chip.styled";
-import { useTheme } from "@mui/material/styles";
 
 import type {
   OutlinedChipProps,
@@ -76,7 +75,6 @@ const ReadOnlyContainedChip = (props: ReadOnlyContainedChipProps) => {
 
 const EnableContainedChip = (props: EnableContainedChipProps) => {
   const { color = "primary", thumbnail, onClick, sx, ...restProps } = props;
-  const theme = useTheme();
 
   return (
     <StyledContainedChip
@@ -91,7 +89,7 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
         },
         "&:hover": {
           // TODO: Below is a temporary color until the hover color is completed in our Design system
-          backgroundColor: theme.palette.token.core.hover,
+          backgroundColor: (theme) => theme.palette.token.core.hover,
         },
         ...sx,
       }}

--- a/packages/design-system/src/components/Chip/Chip.types.ts
+++ b/packages/design-system/src/components/Chip/Chip.types.ts
@@ -3,7 +3,7 @@ import { CHIP_COLORS } from "./consts";
 import type { ChipProps as MuiChipProps, SxProps } from "@mui/material";
 
 type ColorKeys = keyof typeof CHIP_COLORS;
-type ChipColor = typeof CHIP_COLORS[ColorKeys];
+export type ChipColor = typeof CHIP_COLORS[ColorKeys];
 export type ChipThumbnail = string | JSX.Element;
 
 /**

--- a/packages/design-system/src/components/Chip/consts.ts
+++ b/packages/design-system/src/components/Chip/consts.ts
@@ -5,26 +5,3 @@ export const CHIP_COLORS = {
   WARNING: "warning",
   SUCCESS: "success",
 } as const;
-
-export const COMMON_STYLES = {
-  "&.MuiChip-root": {
-    height: "22px",
-    width: "auto",
-    minWidth: "22px",
-  },
-  "&.Mui-disabled": {
-    opacity: 1,
-  },
-  "& .MuiChip-label": {
-    height: "16px",
-    fontStyle: "normal",
-    fontWeight: 500,
-    fontSize: "12px",
-    lineHeight: "16px",
-    display: "flex",
-    alignItems: "center",
-    textAlign: "center",
-    padding: 0,
-    marginInline: "8px",
-  },
-};

--- a/packages/design-system/src/components/Chip/index.ts
+++ b/packages/design-system/src/components/Chip/index.ts
@@ -1,1 +1,1 @@
-export { default as Chip } from "./Chip";
+export { default } from "./Chip";

--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { Box } from "@mui/material";
-import Chip from "@/components/Chip/Chip";
+import Chip from "@/components/Chip";
 import {
   Logo16,
   Avatar16,

--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -93,18 +93,6 @@ export default {
       },
     },
   },
-  decorators: [
-    /**
-     * TODO
-     * Since Color Token system will be changed, below className should be changed accordingly
-     * Also, the hover color will be set again with the color token system completion
-     */
-    (Story) => (
-      <Box className="dark1" sx={{ margin: "3em" }}>
-        {Story()}
-      </Box>
-    ),
-  ],
 } as ComponentMeta<typeof Chip>;
 
 const Template: ComponentStory<typeof Chip> = (args) => <Chip {...args} />;


### PR DESCRIPTION
### Description

- Theme controller 작업이 병합됨에 따라 Chip 스토리북에서 decorator 제거 7930f5e1614b188e681f5c74bab99f2f050bbde4
- 컴포넌트 리팩토링(1): theme을 import하지 않고 sx에서 바로 사용 57b7162adaaf0479b4e619e45362d5996ac72844
- 컴포넌트 리팩토링(2): 반복되던 color token 적용 함수로 빼기 & 불필요하게 전역으로 선언되었던 css 상수를 styled 안으로 이동 9dd4c7924951447760d185c7cf66bf65544df019

### Review Request

- 리팩토링 방향이 옳은지, 과정에서 오류가 생기지는 않았는지 확인해주세요.
- [참고] 현재 DS에서 아래 오류가 발생할 때가 있으나, known issue로 스토리북 7 마이그레이션과 함께 해결될지 지켜볼 예정입니다. 구동에는 문제가 없습니다.
![image](https://user-images.githubusercontent.com/70951555/215408052-3ffd9893-9454-4638-a5d3-30e1a0c01775.png)


### Related Links

- [피그마 링크](https://www.figma.com/file/BSdRUpEPp7XiJ9YnEqpf6F/Components_%EC%9E%91%EC%97%85%EC%9A%A9?node-id=12893%3A225930&t=5r1jZGNoB2d3ily1-1)
- [JIRA 이슈](https://lunit.atlassian.net/jira/software/projects/DS/boards/31?selectedIssue=DS-9)
- [관련 PR](https://github.com/lunit-io/design-system/pull/79) 

### Additional works
- [ ] 컬러 시스템 완성 후 hover 시의 색상 변경 확인
- [ ] Typography theme 적용
- [ ] Docs 좀 더 상세히 작성