### PR TITLE
fix(chip): remove not-working if controls

### DIFF
--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -38,9 +38,6 @@ export default {
         function: action("onClick"),
         undefined: undefined,
       },
-      if: {
-        arg: "contained",
-      },
     },
     onDelete: {
       description:
@@ -54,9 +51,6 @@ export default {
         undefined: undefined,
       },
       defaultValue: null,
-      if: {
-        arg: "contained",
-      },
     },
 
     thumbnail: {
@@ -93,9 +87,6 @@ export default {
         Information16Filled: <Information16 variant="filled" />,
         Warning16: <Warning16 />,
         Warning16Filled: <Warning16 variant="filled" />,
-      },
-      if: {
-        arg: "contained",
       },
     },
   },
@@ -173,10 +164,6 @@ ContainedWithClick.parameters = {
   controls: {
     exclude: ["onDelete", "deletable"],
   },
-  if: {
-    arg: "onDelete",
-    truthy: false,
-  },
 };
 
 export const ContainedWithDelete = Template.bind({});
@@ -193,10 +180,6 @@ ContainedWithDelete.parameters = {
   },
   controls: {
     exclude: ["onClick", "clickable"],
-  },
-  if: {
-    arg: "onClick",
-    truthy: false,
   },
 };
 


### PR DESCRIPTION
Nx 마이그레이션 과정에서 발견된 [잘못된 기술 적용](https://github.com/lunit-io/design-system/pull/88#issuecomment-1432805636)을 발견하고 수정합니다.
- 6.4 버전에서 지원하지 않는 conditional controls 제거
- [관련 PR](https://github.com/lunit-io/design-system/pull/86)

별 문제 없으면 바로 머지하겠습니다.