### PR TITLE
[LDS-2][LDS-9] add hover effect on chip

### DIFF
--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -113,4 +113,19 @@ export const StyledContainedChip = styled(MuiChip, {
     marginLeft: "4px",
     marginRight: "3px",
   },
+
+  "& .delete-icon-hover-layer": {
+    position: "absolute",
+    zIndex: 1000,
+    top: 0,
+    left: "auto",
+    right: 0,
+    bottom: 0,
+    opacity: 0,
+    color: theme.palette.token.core.hover,
+    ":hover": {
+      cursor: "pointer",
+      opacity: 1,
+    },
+  },
 }));

--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -26,7 +26,7 @@ const COMMON_STYLES = {
   },
 };
 
-const getColorToken = (
+export const getColorToken = (
   token: "text" | "bg",
   theme: Theme,
   color?: ChipColor
@@ -112,9 +112,5 @@ export const StyledContainedChip = styled(MuiChip, {
   "& .MuiChip-deleteIcon": {
     marginLeft: "4px",
     marginRight: "3px",
-  },
-  "& .MuiChip-deleteIcon:hover": {
-    // TODO: Below is a temporary color until the hover color is completed in our Design system
-    color: theme.palette.token.core.hover,
   },
 }));

--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -26,7 +26,7 @@ const COMMON_STYLES = {
   },
 };
 
-export const getColorToken = (
+const getColorToken = (
   token: "text" | "bg",
   theme: Theme,
   color?: ChipColor
@@ -74,7 +74,7 @@ export const StyledOutlinedChip = styled(MuiChip, {
   borderColor: getColorToken("text", theme, color),
 }));
 
-export const StyledContainedChip = styled(MuiChip, {
+export const StyledContainedChipBase = styled(MuiChip, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
 })<BaseContainedChipProps>(() => ({ theme, color }) => ({
   ...COMMON_STYLES,
@@ -106,7 +106,40 @@ export const StyledContainedChip = styled(MuiChip, {
     color: getColorToken("bg", theme, color),
     backgroundColor: getColorToken("text", theme, color),
   },
+}));
 
+export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
+  shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
+})<BaseContainedChipProps>(() => ({ theme, color }) => ({
+  /**
+   * Setting the z-index of the chip to 0 and the z-index of the pseudo element to -1
+   * allows the pseudo element(hover layer) to be rendered between the chip and the chip's children.
+   */
+  "&.MuiChip-root": {
+    position: "relative",
+    left: 0,
+    right: 0,
+    zIndex: 0,
+  },
+  "&:hover": {
+    backgroundColor: getColorToken("bg", theme, color),
+  },
+  "&.MuiChip-root:hover::before": {
+    position: "absolute",
+    zIndex: -1,
+    content: '""',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: theme.palette.token.core.hover,
+    borderRadius: "11px",
+  },
+}));
+
+export const StyledContainedChipDeletable = styled(StyledContainedChipBase, {
+  shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
+})<BaseContainedChipProps>(() => ({ theme, color }) => ({
   "& .MuiChip-deleteIcon": {
     marginLeft: "4px",
     marginRight: "3px",

--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -103,8 +103,6 @@ export const StyledContainedChip = styled(MuiChip, {
     display: "flex",
     textAlign: "center",
     alignItems: "center",
-    // TODO: Currently, the color names of Figma and Design system's color component's name don't match
-    // Need to be Fixed after the color system is completed
     color: getColorToken("bg", theme, color),
     backgroundColor: getColorToken("text", theme, color),
   },

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -104,7 +104,7 @@ const DeleteIconWithHoverLayer = ({ onClick }: { onClick: () => void }) => {
   return (
     <>
       <Close16 />
-      <Close16 className={`delete-icon-hover-layer`} onClick={onClick} />
+      <Close16 className="delete-icon-hover-layer" onClick={onClick} />
     </>
   );
 };

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { Avatar } from "@mui/material";
 import { Close16 } from "@lunit/design-system-icons";
-import { StyledOutlinedChip, StyledContainedChip } from "./Chip.styled";
+import {
+  StyledOutlinedChip,
+  StyledContainedChip,
+  getColorToken,
+} from "./Chip.styled";
 
 import type {
   OutlinedChipProps,
@@ -87,9 +91,32 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
         "& .MuiChip-label": {
           ...getLabelMargin(thumbnail),
         },
+        /**
+         * Setting the z-index of the chip to 0 and the z-index of the pseudo element to -1
+         * allows the pseudo element(hover layer) to be rendered between the chip and the chip's children.
+         */
+        "&.MuiChip-root": {
+          height: "22px",
+          width: "auto",
+          minWidth: "22px",
+          position: "relative",
+          left: 0,
+          right: 0,
+          zIndex: 0,
+        },
         "&:hover": {
-          // TODO: Below is a temporary color until the hover color is completed in our Design system
+          backgroundColor: (theme) => getColorToken("bg", theme, color),
+        },
+        "&.MuiChip-root:hover::before": {
+          position: "absolute",
+          zIndex: -1,
+          content: '""',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
           backgroundColor: (theme) => theme.palette.token.core.hover,
+          borderRadius: "11px",
         },
         ...sx,
       }}
@@ -98,14 +125,46 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
 };
 
 const DeletableContainedChip = (props: DeletableContainedChipProps) => {
-  const { color = "primary", thumbnail, onDelete, sx, ...restProps } = props;
+  const {
+    color = "primary",
+    thumbnail,
+    onDelete,
+    className,
+    sx,
+    ...restProps
+  } = props;
+  const DeleteIconWithHoverEffect = () => {
+    return (
+      <>
+        <Close16 />
+        <Close16
+          className={className}
+          sx={{
+            position: "absolute",
+            zIndex: 1000,
+            top: 0,
+            left: "auto",
+            right: 0,
+            bottom: 0,
+            opacity: 0,
+            // color: (theme) => theme.palette.token.core.text_warning,
+            color: (theme) => theme.palette.token.core.hover,
+            ":hover": {
+              cursor: "pointer",
+              opacity: 1,
+            },
+          }}
+        />
+      </>
+    );
+  };
 
   return (
     <StyledContainedChip
       {...restProps}
       color={color}
       onDelete={onDelete}
-      deleteIcon={<Close16 />}
+      deleteIcon={<DeleteIconWithHoverEffect />}
       avatar={getAvatar(thumbnail)}
       icon={getIcon(thumbnail)}
       sx={{

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -3,8 +3,9 @@ import { Avatar } from "@mui/material";
 import { Close16 } from "@lunit/design-system-icons";
 import {
   StyledOutlinedChip,
-  StyledContainedChip,
-  getColorToken,
+  StyledContainedChipBase,
+  StyledContainedChipEnable,
+  StyledContainedChipDeletable,
 } from "./Chip.styled";
 
 import type {
@@ -64,7 +65,7 @@ const ReadOnlyContainedChip = (props: ReadOnlyContainedChipProps) => {
   const { color = "primary", thumbnail, sx, ...restProps } = props;
 
   return (
-    <StyledContainedChip
+    <StyledContainedChipBase
       {...restProps}
       disabled
       avatar={getAvatar(thumbnail)}
@@ -84,7 +85,7 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
   const { color = "primary", thumbnail, onClick, sx, ...restProps } = props;
 
   return (
-    <StyledContainedChip
+    <StyledContainedChipEnable
       {...restProps}
       onClick={onClick}
       avatar={getAvatar(thumbnail)}
@@ -94,31 +95,6 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
         "& .MuiChip-label": {
           ...getLabelMargin(thumbnail),
         },
-        /**
-         * Setting the z-index of the chip to 0 and the z-index of the pseudo element to -1
-         * allows the pseudo element(hover layer) to be rendered between the chip and the chip's children.
-         */
-        "&.MuiChip-root": {
-          position: "relative",
-          left: 0,
-          right: 0,
-          zIndex: 0,
-        },
-        "&:hover": {
-          backgroundColor: (theme) => getColorToken("bg", theme, color),
-        },
-        "&.MuiChip-root:hover::before": {
-          position: "absolute",
-          zIndex: -1,
-          content: '""',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: (theme) => theme.palette.token.core.hover,
-          borderRadius: "11px",
-        },
-        ...sx,
       }}
     />
   );
@@ -136,7 +112,7 @@ const DeletableContainedChip = (props: DeletableContainedChipProps) => {
   const { color = "primary", thumbnail, onDelete, sx, ...restProps } = props;
 
   return (
-    <StyledContainedChip
+    <StyledContainedChipDeletable
       {...restProps}
       color={color}
       onDelete={onDelete}

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -96,9 +96,6 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
          * allows the pseudo element(hover layer) to be rendered between the chip and the chip's children.
          */
         "&.MuiChip-root": {
-          height: "22px",
-          width: "auto",
-          minWidth: "22px",
           position: "relative",
           left: 0,
           right: 0,
@@ -133,7 +130,7 @@ const DeletableContainedChip = (props: DeletableContainedChipProps) => {
     sx,
     ...restProps
   } = props;
-  const DeleteIconWithHoverEffect = () => {
+  const DeleteIconWithHoverLayer = () => {
     return (
       <>
         <Close16 />
@@ -147,7 +144,7 @@ const DeletableContainedChip = (props: DeletableContainedChipProps) => {
       {...restProps}
       color={color}
       onDelete={onDelete}
-      deleteIcon={<DeleteIconWithHoverEffect />}
+      deleteIcon={<DeleteIconWithHoverLayer />}
       avatar={getAvatar(thumbnail)}
       icon={getIcon(thumbnail)}
       sx={{

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -137,24 +137,7 @@ const DeletableContainedChip = (props: DeletableContainedChipProps) => {
     return (
       <>
         <Close16 />
-        <Close16
-          className={className}
-          sx={{
-            position: "absolute",
-            zIndex: 1000,
-            top: 0,
-            left: "auto",
-            right: 0,
-            bottom: 0,
-            opacity: 0,
-            // color: (theme) => theme.palette.token.core.text_warning,
-            color: (theme) => theme.palette.token.core.hover,
-            ":hover": {
-              cursor: "pointer",
-              opacity: 1,
-            },
-          }}
-        />
+        <Close16 className={`${className} delete-icon-hover-layer`} />
       </>
     );
   };

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -124,30 +124,23 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
   );
 };
 
+const DeleteIconWithHoverLayer = ({ onClick }: { onClick: () => void }) => {
+  return (
+    <>
+      <Close16 />
+      <Close16 className={`delete-icon-hover-layer`} onClick={onClick} />
+    </>
+  );
+};
 const DeletableContainedChip = (props: DeletableContainedChipProps) => {
-  const {
-    color = "primary",
-    thumbnail,
-    onDelete,
-    className,
-    sx,
-    ...restProps
-  } = props;
-  const DeleteIconWithHoverLayer = () => {
-    return (
-      <>
-        <Close16 />
-        <Close16 className={`${className} delete-icon-hover-layer`} />
-      </>
-    );
-  };
+  const { color = "primary", thumbnail, onDelete, sx, ...restProps } = props;
 
   return (
     <StyledContainedChip
       {...restProps}
       color={color}
       onDelete={onDelete}
-      deleteIcon={<DeleteIconWithHoverLayer />}
+      deleteIcon={<DeleteIconWithHoverLayer onClick={onDelete} />}
       avatar={getAvatar(thumbnail)}
       icon={getIcon(thumbnail)}
       sx={{

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -38,6 +38,9 @@ const OutlinedChip = (props: OutlinedChipProps) => {
   );
 };
 
+/**
+ * Conditional styling for contained chip
+ */
 const getAvatar = (thumbnail: ChipThumbnail | undefined) => {
   if (!thumbnail || typeof thumbnail !== "string") return;
   if (thumbnail.length === 0) return <Avatar />;


### PR DESCRIPTION
### Description

- 컴포넌트 단에서 core.hover 레이어를 입히기로 결정함에 따라 chip에 hover 구현
- Chip의 deleteIcon은 `:before`로 가상 엘리먼트를 구현할 수 없으므로 core.hover 색상을 입힌 deleteIcon을 위에 겹쳐서 구현
 
### Review Request

- 아래 Develop Backgrounds에 루닛 컬러 시스템의 hover 레이어 구현과 관련된 그간의 논의를 정리해놓았으니 확인 부탁드립니다.


### Related Links

- [피그마 링크 - color](https://www.figma.com/file/yA3cytTNAqhNoXaGxAPrS7/Lunit_Color?node-id=2%3A2&t=smPUUmjhGTAsh8yX-1)
- [피그마 링크 - chip](https://www.figma.com/file/BSdRUpEPp7XiJ9YnEqpf6F/Components_%EC%9E%91%EC%97%85%EC%9A%A9?node-id=12893%3A225930&t=5r1jZGNoB2d3ily1-1)
- [core.hover 컬러 적용과 관련된 JIRA 이슈 코멘트](https://lunit.atlassian.net/browse/DS-2?focusedCommentId=29204)


### Develop Backgrounds

1. 디자인 상에서의 hover 컬러는 아래와 같이 state layer가 Container와 Contents 사이에 위치하여 표현됩니다.
	state layer 방식이 고안된 이유는 light1, light2, dark1, dark2, dark3, dark4에 따라서 달라져야 하는 token 별 hover 색상을 모두 정의하기에는 색상 생성/수정/유지 차원에서 무리가 있기 때문이었습니다. 
<img width="752" alt="image" src="https://user-images.githubusercontent.com/70951555/220246842-eb14a178-c510-4f19-8d70-f0c678096ae5.png">

2. 따라서 개발 상으로는 위처럼 Container 컬러 위에 state layer가 겹쳐서 표현되는 hover 컬러를 구현할 방법을 찾아야 했습니다.
3. 처음 토큰별 hover 컬러 구현을 위하여 고려된 방식은 컬러 합성함수 작성입니다. <br>색상 합성 원리 [(Alpha compositing)](https://en.wikipedia.org/wiki/Alpha_compositing#Description)를 이용해 직접 합성 함수를 만들어낼 수도 있지만, 이미 존재하는 라이브러리를 이용하는 방법도 있었으며 그 후보군은 아래와 같습니다.
    1. mui 라이브러리의 darken 함수 이용
    2. scss 라이브러리의 darken과 css variables 함께 이용([참고 문서](https://medium.com/beyn-technology/using-css-variables-in-scss-functions-9521be4de4e3))
    4. color-composite의 over 함수 이용([color-composite](https://github.com/colorjs/color-composite), [color-space](https://github.com/colorjs/color-space) 문서 참고)
    
3. 그러나 어떤 방법을 적용하든 컬러 합성 함수 제작은 모두 현재의 컬러 시스템 구현(css variables 이용) 혹은 mui의 styled components과 동시 사용하기 어려워 반려되었습니다. 
4. 그 이후 제안된 방식이 본 PR에서 시범적으로 적용해본 가상 엘리먼트를 이용한 state layer 삽입입니다. <br> Container와 Contents 엘리먼트 사이에 실제 dom을 추가하는 것이 아닌, css `:before`를 이용하여 Pseudo-elements를 삽입해 state layer를 구현합니다. 컬러 토큰 별 hover 색상을 color theme에서 관리하지 못하고 각 컴포넌트 개발자가 일일이 state layer를 삽입해주어야 하는 단점이 있으나, 가장 정확하게 디자인 요구 사항을 반영할 수 있는 방법이라 채택되었습니다.<br> 단, [replaced-elements](https://web.archive.org/web/20170103232556/http://red-team-design.com/css-generated-content-replaced-elements/)인 svg에서는 css 가상 엘리먼트가 생성되지 않아 주의해야 합니다. chip에서는 deleteIcon인 CloseIcon 위에 core.hover 색상이 적용된 CloseIcon 하나를 겹치고, hover 시에만 CloseIcon-hover의 opacity를 100%로 조정하는 방식으로 replaced-elements 관련 문제를 해결했습니다. 
