### PR TITLE
build design-system package

### DIFF
--- a/packages/design-system/.npmignore
+++ b/packages/design-system/.npmignore
@@ -1,0 +1,3 @@
+.storybook
+config
+src

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -2,8 +2,26 @@
   "name": "@lunit/design-system",
   "version": "0.1.0",
   "description": "Lunit Design System",
-  "main": "dist/design-system.js",
-  "module": "src/index.ts",
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/components/*/index.d.ts",
+      "default": "./dist/components/*/index.js"
+    }
+  },
+  "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/components/*/index.d.ts",
+        "dist/index.d.ts"
+      ]
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -53,14 +71,16 @@
     "ts-loader": "^9.3.0",
     "typescript": "^4.6.4",
     "webpack": "^5.72.0",
-    "webpack-cli": "^4.9.2"
+    "webpack-cli": "^4.9.2",
+    "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
     "@lunit/design-system-icons": "*"
   },
   "peerDependencies": {
     "@mui/material": "^5.0.0",
-    "react": ">=17",
-    "react-dom": ">=17"
+    "@types/react": "^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   }
 }

--- a/packages/design-system/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/design-system/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import MuiToggleButtonGroup, {
+  ToggleButtonGroupProps,
+} from "@mui/material/ToggleButtonGroup";
+
+const ToggleButtonGroup = ({
+  size = "small",
+  ...props
+}: ToggleButtonGroupProps) => {
+  return <MuiToggleButtonGroup size={size} {...props} />;
+};
+
+export default ToggleButtonGroup;

--- a/packages/design-system/src/components/ToggleButtonGroup/index.tsx
+++ b/packages/design-system/src/components/ToggleButtonGroup/index.tsx
@@ -1,13 +1,1 @@
-import React from "react";
-import MuiToggleButtonGroup, {
-  ToggleButtonGroupProps,
-} from "@mui/material/ToggleButtonGroup";
-
-const ToggleButtonGroup = ({
-  size = "small",
-  ...props
-}: ToggleButtonGroupProps) => {
-  return <MuiToggleButtonGroup size={size} {...props} />;
-};
-
-export default ToggleButtonGroup;
+export { default } from "./ToggleButtonGroup";

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,5 +1,17 @@
-function hello() {
-  return "Hello world";
-}
+export { default as theme } from "./theme";
 
-export default hello;
+export { default as Alert } from "./components/Alert";
+export { default as Button } from "./components/Button";
+export { default as Chip } from "./components/Chip";
+export { default as DataTable } from "./components/DataTable";
+export { default as DatePicker } from "./components/DatePicker";
+export { default as Dropdown } from "./components/Dropdown";
+export { default as FormLabel } from "./components/FormLabel";
+export { default as Modal } from "./components/Modal";
+export { default as Radio } from "./components/Radio";
+export { default as RadioGroup } from "./components/RadioGroup";
+export { default as TextField } from "./components/TextField";
+export { default as Toggle } from "./components/Toggle";
+export { default as ToggleButton } from "./components/ToggleButton";
+export { default as ToggleButtonGroup } from "./components/ToggleButtonGroup";
+export { default as Tooltip } from "./components/Tooltip";

--- a/packages/design-system/tsconfig.build.json
+++ b/packages/design-system/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "declaration": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/stories/**",
+    "src/**/__tests__/**/*.ts",
+    "src/**/__tests__/**/*.tsx"
+  ]
+}

--- a/packages/design-system/webpack.config.js
+++ b/packages/design-system/webpack.config.js
@@ -1,4 +1,6 @@
+const glob = require("glob");
 const path = require("path");
+const nodeExternals = require("webpack-node-externals");
 const alias = require("./config/alias");
 
 console.log(path.resolve(__dirname, "src"));
@@ -6,13 +8,34 @@ console.log(path.resolve(__dirname, "src"));
 module.exports = {
   mode: "production",
   entry: "./src/index.ts",
+  entry: glob.sync("./src/components/*/index.ts").reduce(
+    function (obj, el) {
+      const name = el.substring(6 /* ./src/ */, el.lastIndexOf("/"));
+      obj[name] = el;
+      return obj;
+    },
+    { main: "./src/index.ts" }
+  ),
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: (pathData) => {
+      return pathData.chunk.name === "main" ? "index.js" : "[name]/index.js";
+    },
+    library: {
+      type: "commonjs-static",
+    },
+    clean: true,
+  },
   devtool: "source-map",
   module: {
     rules: [
       {
         test: /\.tsx?$/,
-        use: "ts-loader",
+        loader: "ts-loader",
         exclude: /node_modules/,
+        options: {
+          configFile: "tsconfig.build.json",
+        },
       },
     ],
   },
@@ -20,11 +43,9 @@ module.exports = {
     alias,
     extensions: [".tsx", ".ts", ".js"],
   },
-  output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: "design-system.js",
-    library: {
-      type: "commonjs-static",
-    },
-  },
+  externals: [
+    nodeExternals({
+      modulesFromFile: true,
+    }),
+  ],
 };


### PR DESCRIPTION
`@lunit/design-system` 패키지 빌드를 위한 PR입니다.

## Usage

Mui는 Peer Dependencies로 지정되어 있으므로, 직접 설치해야 합니다.
```sh
npm install @mui/material @emotion/react @emotion/styled
npm install @lunit/design-system
```


```tsx
import { ThemeProvider, CssBaseline } from "@mui/material";
import { theme } from '@lunit/design-system';
import Button from '@lunit/design-system/Button'

function App() {
  return (
    <ThemeProvider theme={theme}>
      <CssBaseline />
      <div className="light1">
        <Button>Click Me!</Button>
      </div>
    </ThemeProvider>
  )
}

export default App
```

CommonJS와 ESM으로 모두 사용 가능하며, Top-level과 Subpath import를 지원합니다.

```ts
import Button from '@lunit/design-system/Button'
// or
import { Button } from '@lunit/design-system';
```
