### PR TITLE
[Button] Add hover style

### DIFF
--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -22,6 +22,14 @@ type sizeStyleParams = Pick<
 > &
   Pick<ToggleButtonProps, "selected"> & { typography: Typography };
 
+const borderRadius = "8px";
+
+const hoverStyle = (backgroundColor: React.CSSProperties["color"]) => ({
+  position: "relative",
+  zIndex: 0,
+  backgroundColor,
+});
+
 export const sizeStyle = ({
   size,
   kind,
@@ -67,9 +75,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "primary" && {
       color: token.component.btn_contained_primary_text,
       backgroundColor: token.component.btn_contained_primary_bg,
-      "&:hover": {
-        backgroundColor: token.component.btn_contained_primary_bg,
-      },
+      "&:hover": hoverStyle(token.component.btn_contained_primary_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -79,10 +85,9 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
   ...(kind === "contained" &&
     color === "secondary" && {
       color: token.component.btn_contained_secondary_text,
+
       backgroundColor: token.component.btn_contained_secondary_bg,
-      "&:hover": {
-        backgroundColor: token.component.btn_contained_secondary_bg,
-      },
+      "&:hover": hoverStyle(token.component.btn_contained_secondary_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -93,9 +98,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "error" && {
       color: token.component.btn_contained_error_text,
       backgroundColor: token.component.btn_contained_error_bg,
-      "&:hover": {
-        backgroundColor: token.component.btn_contained_error_bg,
-      },
+      "&:hover": hoverStyle(token.component.btn_contained_error_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -107,9 +110,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "primary" && {
       color: token.component.btn_ghost_primary_text,
       border: "none",
-      "&:hover": {
-        backgroundColor: "rgba(0, 0, 0, 0.06)",
-      },
+      "&:hover": hoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -120,9 +121,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "secondary" && {
       color: token.component.btn_ghost_secondary_text,
       border: "none",
-      "&:hover": {
-        backgroundColor: "rgba(0, 0, 0, 0.06)",
-      },
+      "&:hover": hoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -132,9 +131,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
   ...(kind === "ghost" &&
     color === "error" && {
       color: token.component.btn_ghost_error_text,
-      "&:hover": {
-        backgroundColor: "rgba(0, 0, 0, 0.06)",
-      },
+      "&:hover": hoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -146,9 +143,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "primary" && {
       color: token.component.btn_outlined_primary_text,
       border: `${OUTLINED_BORDER_WIDTH}px solid ${token.component.btn_outlined_primary_border}`,
-      "&:hover": {
-        backgroundColor: "rgba(0, 0, 0, 0.06)", // TODO: color util function 추가 후 변경
-      },
+      "&:hover": hoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         color: token.component.btn_outlined_primary_text,
@@ -159,7 +154,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
 export const commonStyle = ({ token }: { token: ColorToken }) =>
   ({
     fontWeight: "500",
-    borderRadius: "8px",
+    borderRadius,
     textTransform: "initial",
     "&.Mui-focusVisible": {
       "&::after": {
@@ -171,6 +166,17 @@ export const commonStyle = ({ token }: { token: ColorToken }) =>
         border: `1px solid ${token.core.focused}`,
         boxSizing: "border-box",
       },
+    },
+    "&:hover:before": {
+      content: "''",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: "100%",
+      height: "100%",
+      zIndex: -1,
+      backgroundColor: token.core.hover,
+      borderRadius,
     },
   } as const);
 

--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -5,6 +5,7 @@ import { ColorToken } from "@/foundation/colors/types";
 import { PADDING_OF_FOCUS, OUTLINED_BORDER_WIDTH } from "./const";
 import { getButtonPaddingBySizeAndKind } from "./utils/getButtonPaddingBySizeAndKind";
 import { getIconButtonPaddingBySizeAndKind } from "./utils/getIconButtonPaddingBySizeAndKind";
+import getHoverStyle from "./utils/getHoverStyle";
 
 import type { ButtonProps } from "./Button.types";
 import type { ToggleButtonProps } from "../ToggleButton/ToggleButton.types";
@@ -23,12 +24,6 @@ type sizeStyleParams = Pick<
   Pick<ToggleButtonProps, "selected"> & { typography: Typography };
 
 const borderRadius = "8px";
-
-const hoverStyle = (backgroundColor: React.CSSProperties["color"]) => ({
-  position: "relative",
-  zIndex: 0,
-  backgroundColor,
-});
 
 export const sizeStyle = ({
   size,
@@ -75,7 +70,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "primary" && {
       color: token.component.btn_contained_primary_text,
       backgroundColor: token.component.btn_contained_primary_bg,
-      "&:hover": hoverStyle(token.component.btn_contained_primary_bg),
+      "&:hover": getHoverStyle(token.component.btn_contained_primary_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -87,7 +82,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
       color: token.component.btn_contained_secondary_text,
 
       backgroundColor: token.component.btn_contained_secondary_bg,
-      "&:hover": hoverStyle(token.component.btn_contained_secondary_bg),
+      "&:hover": getHoverStyle(token.component.btn_contained_secondary_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -98,7 +93,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "error" && {
       color: token.component.btn_contained_error_text,
       backgroundColor: token.component.btn_contained_error_bg,
-      "&:hover": hoverStyle(token.component.btn_contained_error_bg),
+      "&:hover": getHoverStyle(token.component.btn_contained_error_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -110,7 +105,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "primary" && {
       color: token.component.btn_ghost_primary_text,
       border: "none",
-      "&:hover": hoverStyle("none"),
+      "&:hover": getHoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -121,7 +116,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "secondary" && {
       color: token.component.btn_ghost_secondary_text,
       border: "none",
-      "&:hover": hoverStyle("none"),
+      "&:hover": getHoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -131,7 +126,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
   ...(kind === "ghost" &&
     color === "error" && {
       color: token.component.btn_ghost_error_text,
-      "&:hover": hoverStyle("none"),
+      "&:hover": getHoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
@@ -143,7 +138,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
     color === "primary" && {
       color: token.component.btn_outlined_primary_text,
       border: `${OUTLINED_BORDER_WIDTH}px solid ${token.component.btn_outlined_primary_border}`,
-      "&:hover": hoverStyle("none"),
+      "&:hover": getHoverStyle("none"),
       "&:hover:before": {
         content: "''",
         position: "absolute",

--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -144,6 +144,17 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
       color: token.component.btn_outlined_primary_text,
       border: `${OUTLINED_BORDER_WIDTH}px solid ${token.component.btn_outlined_primary_border}`,
       "&:hover": hoverStyle("none"),
+      "&:hover:before": {
+        content: "''",
+        position: "absolute",
+        left: "-1px",
+        top: "-1px",
+        width: "calc(100% + 2px)",
+        height: "calc(100% + 2px)",
+        zIndex: -1,
+        backgroundColor: token.core.hover,
+        borderRadius,
+      },
       "&.Mui-disabled": {
         opacity: 0.38,
         color: token.component.btn_outlined_primary_text,

--- a/packages/design-system/src/components/Button/utils/getHoverStyle.ts
+++ b/packages/design-system/src/components/Button/utils/getHoverStyle.ts
@@ -1,0 +1,7 @@
+const getHoverStyle = (backgroundColor: React.CSSProperties["color"]) => ({
+  position: "relative",
+  zIndex: 0,
+  backgroundColor,
+});
+
+export default getHoverStyle;

--- a/packages/design-system/src/stories/components/Button/Kind.stories.tsx
+++ b/packages/design-system/src/stories/components/Button/Kind.stories.tsx
@@ -68,6 +68,17 @@ export default {
     controls: {
       include: ["onClick", "children", "color", "size", "disabled", "kind"],
     },
+    pseudo: {
+      hover: [
+        "#hover1",
+        "#hover2",
+        "#hover3",
+        "#hover4",
+        "#hover5",
+        "#hover6",
+        "#hover7",
+      ],
+    },
     docs: {
       description: {
         component: `It is a kind Button docs. For more details, please
@@ -190,17 +201,17 @@ const ContainedButtonTemplate: ComponentStory<typeof Button> = (args) => {
               Hover
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover" kind="contained">
+              <Button {...args} id="hover1" kind="contained">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover" kind="contained" color="secondary">
+              <Button {...args} id="hover2" kind="contained" color="secondary">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover" kind="contained" color="error">
+              <Button {...args} id="hover3" kind="contained" color="error">
                 {args.children}
               </Button>
             </TableCell>
@@ -329,17 +340,17 @@ const GhostButtonTemplate: ComponentStory<typeof Button> = (args) => {
               Hover
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover" kind="ghost">
+              <Button {...args} id="hover4" kind="ghost">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover" kind="ghost" color="secondary">
+              <Button {...args} id="hover5" kind="ghost" color="secondary">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover" kind="ghost" color="error">
+              <Button {...args} id="hover6" kind="ghost" color="error">
                 {args.children}
               </Button>
             </TableCell>
@@ -457,7 +468,7 @@ const OutlinedButtonTemplate: ComponentStory<typeof Button> = ({
               Hover
             </TableCell>
             <TableCell>
-              <Button {...restProps} id="hover" kind="outlined">
+              <Button {...restProps} id="hover7" kind="outlined">
                 Text
               </Button>
             </TableCell>

--- a/packages/design-system/src/stories/components/ToggleButton/ToggleButtonKind.stories.tsx
+++ b/packages/design-system/src/stories/components/ToggleButton/ToggleButtonKind.stories.tsx
@@ -124,6 +124,9 @@ export default {
 				see [Material-UI Toggle Button](https://mui.com/material-ui/react-toggle-button/).`,
       },
     },
+    pseudo: {
+      hover: ["#hover1", "#hover2", "#hover3"],
+    },
   },
 } as ComponentMeta<typeof ToggleButton>;
 
@@ -308,7 +311,7 @@ const ContainedTemplate: ComponentStory<typeof ToggleButton> = (args) => {
           <TableCell>
             <ToggleButton
               {...args}
-              id="hover"
+              id="hover1"
               kind="contained"
               value="hover"
               onChange={() => handleChange("primary", "hover")}
@@ -320,7 +323,7 @@ const ContainedTemplate: ComponentStory<typeof ToggleButton> = (args) => {
           <TableCell>
             <ToggleButton
               {...args}
-              id="hover"
+              id="hover2"
               kind="contained"
               color="secondary"
               value="hover"
@@ -477,7 +480,7 @@ const GhostTemplate: ComponentStory<typeof ToggleButton> = (args) => {
             <TableCell>
               <ToggleButton
                 {...args}
-                id="hover"
+                id="hover1"
                 kind="ghost"
                 value="hover"
                 onChange={() => handleChange("primary", "hover")}
@@ -489,7 +492,7 @@ const GhostTemplate: ComponentStory<typeof ToggleButton> = (args) => {
             <TableCell>
               <ToggleButton
                 {...args}
-                id="hover"
+                id="hover2"
                 kind="ghost"
                 color="secondary"
                 value="hover"
@@ -636,7 +639,7 @@ const OutlinedTemplate: ComponentStory<typeof ToggleButton> = ({
             <TableCell>
               <ToggleButton
                 {...restProps}
-                id="hover"
+                id="hover1"
                 kind="outlined"
                 value="hover"
                 onChange={() => handleChange("primary", "hover")}


### PR DESCRIPTION
# Description

**Button**과 **Toggle Button**에 hover style을 추가하였습니다. 

<img width="908" alt="image" src="https://user-images.githubusercontent.com/36615680/221501132-a0616784-abbc-4e39-ba93-ee848acd2ae7.png">


<img width="756" alt="image" src="https://user-images.githubusercontent.com/36615680/221501219-1d170883-596d-4b0b-97fb-bab41fa333ef.png">

캡쳐화면인 style book kind별 hover style정의는 로컬에서만 보여지는 이슈가 있습니다. 
Chromatic에선 ghost와 outlined만 스냅샷이 만들어 졌습니다. 😓
