### PR TITLE
[LDS-9] remove ripple effect on clickable chip & add storynames

### DIFF
--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -6,6 +6,9 @@ import type {
   ChipColor,
   OutlinedChipProps,
   BaseContainedChipProps,
+  ReadOnlyContainedChipProps,
+  EnableContainedChipProps,
+  DeletableContainedChipProps,
 } from "./Chip.types";
 
 const COMMON_STYLES = {
@@ -110,7 +113,7 @@ export const StyledContainedChipBase = styled(MuiChip, {
 
 export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<BaseContainedChipProps>(() => ({ theme, color }) => ({
+})<EnableContainedChipProps>(() => ({ theme, color }) => ({
   /**
    * Setting the z-index of the chip to 0 and the z-index of the pseudo element to -1
    * allows the pseudo element(hover layer) to be rendered between the chip and the chip's children.
@@ -137,9 +140,9 @@ export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
   },
 }));
 
-export const StyledContainedChipDeletable = styled(StyledContainedChipBase, {
-  shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<BaseContainedChipProps>(() => ({ theme, color }) => ({
+export const StyledContainedChipDeletable = styled(
+  StyledContainedChipBase
+)<BaseContainedChipProps>(() => ({ theme }) => ({
   "& .MuiChip-deleteIcon": {
     marginLeft: "4px",
     marginRight: "3px",

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -91,6 +91,8 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
       avatar={getAvatar(thumbnail)}
       icon={getIcon(thumbnail)}
       color={color}
+      disableRipple
+      disableFocusRipple
       sx={{
         "& .MuiChip-label": {
           ...getLabelMargin(thumbnail),

--- a/packages/design-system/src/components/Chip/Chip.types.ts
+++ b/packages/design-system/src/components/Chip/Chip.types.ts
@@ -1,9 +1,9 @@
 import { CHIP_COLORS } from "./consts";
 
-import type { ChipProps as MuiChipProps, SxProps } from "@mui/material";
+import type { ChipProps as MuiChipProps } from "@mui/material";
 
 type ColorKeys = keyof typeof CHIP_COLORS;
-export type ChipColor = typeof CHIP_COLORS[ColorKeys];
+export type ChipColor = (typeof CHIP_COLORS)[ColorKeys];
 export type ChipThumbnail = string | JSX.Element;
 
 /**
@@ -42,6 +42,8 @@ export interface ReadOnlyContainedChipProps extends BaseContainedChipProps {
 export interface EnableContainedChipProps extends BaseContainedChipProps {
   onClick: () => void;
   onDelete?: never;
+  disableRipple: boolean;
+  disableFocusRipple: boolean;
 }
 export interface DeletableContainedChipProps extends BaseContainedChipProps {
   onClick?: never;

--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -131,6 +131,7 @@ Outlined.args = {
   color: "primary",
   kind: "outlined",
 };
+Outlined.storyName = "Kind: Outlined";
 
 export const Contained = Template.bind({});
 Contained.parameters = {
@@ -149,6 +150,7 @@ Contained.args = {
   color: "primary",
   kind: "contained",
 };
+Contained.storyName = "Kind: Contained / Read Only";
 
 export const ContainedWithClick = Template.bind({});
 ContainedWithClick.args = {
@@ -165,6 +167,7 @@ ContainedWithClick.parameters = {
     exclude: ["onDelete", "deletable"],
   },
 };
+ContainedWithClick.storyName = "Kind: Contained / Enable";
 
 export const ContainedWithDelete = Template.bind({});
 ContainedWithDelete.args = {
@@ -182,6 +185,7 @@ ContainedWithDelete.parameters = {
     exclude: ["onClick", "clickable"],
   },
 };
+ContainedWithDelete.storyName = "Kind: Contained / Deletable";
 
 export const ContainedWithThumbnail = Template.bind({});
 ContainedWithThumbnail.args = {
@@ -194,3 +198,4 @@ ContainedWithThumbnail.parameters = {
     },
   },
 };
+ContainedWithThumbnail.storyName = "Kind: Contained with Thumbnail";


### PR DESCRIPTION
### Description

- 디자인 요구로 chip 클릭 시 생성되는 ripple 효과 제거
- 문서 확인이 용이하도록 storyname 추가
 
### Review Request

- 클릭 시 나타나던 ripple 효과가 잘 제거되었는지 확인해주세요.
- Button 등과 storyName 형식이 같아지는 게 나을 듯해서 Chip에도 storyName을 아래와 같이 추가했습니다. 괜찮은지 의견 부탁드립니다.
<img width="1717" alt="image" src="https://user-images.githubusercontent.com/70951555/222482345-c452a5de-d208-489c-bd5f-6897015faf7b.png">

### Related Links

- [피그마 링크 - chip](https://www.figma.com/file/BSdRUpEPp7XiJ9YnEqpf6F/Components_%EC%9E%91%EC%97%85%EC%9A%A9?node-id=12893%3A225930&t=5r1jZGNoB2d3ily1-1)

