### PR TITLE
Remove hasIconOnly props to Button

### DIFF
--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -4,7 +4,7 @@ import { CustomButton } from "./Button.styled";
 
 import type { ButtonProps } from "./Button.types";
 
-const Button = (props: Omit<ButtonProps, "hasIconOnly">) => {
+const Button = (props: ButtonProps) => {
   const {
     kind = "contained",
     size = "small",

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -1,20 +1,20 @@
 import type { ButtonProps as MuiButtonProps } from "@mui/material";
 
-interface BaseButtonProps extends MuiButtonProps {
+interface BaseButtonProps extends Omit<MuiButtonProps, "variant"> {
   icon?: React.ReactNode;
 }
 
-interface ContainedButtonProps extends Omit<BaseButtonProps, "variant"> {
+interface ContainedButtonProps extends BaseButtonProps {
   kind?: "contained";
   color?: "primary" | "secondary" | "error";
 }
 
-interface GhostButtonProps extends Omit<BaseButtonProps, "variant"> {
+interface GhostButtonProps extends BaseButtonProps {
   kind?: "ghost";
   color?: "primary" | "secondary" | "error";
 }
 
-interface OutlinedButtonProps extends Omit<BaseButtonProps, "variant"> {
+interface OutlinedButtonProps extends BaseButtonProps {
   kind?: "outlined";
   color?: "primary";
 }

--- a/packages/design-system/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/design-system/src/components/ToggleButton/ToggleButton.types.ts
@@ -1,23 +1,20 @@
 import type { ToggleButtonProps as MuiToggleButtonProps } from "@mui/material";
 
-interface ToggleButtonBaseProps extends MuiToggleButtonProps {
+interface ToggleButtonBaseProps extends Omit<MuiToggleButtonProps, "variant"> {
   selectedColor?: "primary" | "secondary";
   icon?: React.ReactNode;
 }
-interface ContainedToggleButtonProps
-  extends Omit<ToggleButtonBaseProps, "variant"> {
+interface ContainedToggleButtonProps extends ToggleButtonBaseProps {
   kind?: "contained";
   color?: "primary" | "secondary";
 }
 
-interface GhostToggleButtonProps
-  extends Omit<ToggleButtonBaseProps, "variant"> {
+interface GhostToggleButtonProps extends ToggleButtonBaseProps {
   kind?: "ghost";
   color?: "primary" | "secondary";
 }
 
-interface OutlinedToggleButtonProps
-  extends Omit<ToggleButtonBaseProps, "variant"> {
+interface OutlinedToggleButtonProps extends ToggleButtonBaseProps {
   kind?: "outlined";
   color?: "primary";
 }

--- a/packages/design-system/src/stories/components/Button/BasicButton.stories.tsx
+++ b/packages/design-system/src/stories/components/Button/BasicButton.stories.tsx
@@ -7,7 +7,7 @@ import {
   TableBody,
   TableCell,
 } from "@mui/material";
-import { Bell } from "@lunit/design-system-icons";
+import Bell from "@lunit/design-system-icons/Bell";
 
 import Button from "@/components/Button";
 
@@ -25,22 +25,10 @@ export default {
     icon: {
       control: false,
       description: `Use this prop when you want to add icon.
-        \n It is added to the left of the text criteria,
-        \n and only Icon can be checked when used with hasIconOnly.`,
+        \n It is added to the left of the text criteria`,
       table: {
         defaultValue: { summary: "undefined" },
         type: { summary: "React.ReactNode" },
-      },
-    },
-    hasIconOnly: {
-      control: {
-        type: "boolean",
-      },
-      description: `Option to handle so that only icons can be inserted
-          \n If set to false, you can add Text.`,
-      defaultValue: false,
-      table: {
-        defaultValue: { summary: "false" },
       },
     },
     children: {
@@ -112,7 +100,6 @@ export default {
         "kind",
         "color",
         "icon",
-        "hasIconOnly",
       ],
     },
     docs: {

--- a/packages/design-system/src/stories/components/Button/IconButton.stories.tsx
+++ b/packages/design-system/src/stories/components/Button/IconButton.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Bell } from "@lunit/design-system-icons";
+import Bell from "@lunit/design-system-icons/Bell";
 import { action } from "@storybook/addon-actions";
 
 import Button from "@/components/Button";
@@ -13,8 +13,7 @@ export default {
     icon: {
       control: false,
       description: `Use this prop when you want to add icon.
-        \n It is added to the left of the text criteria,
-        \n and only Icon can be checked when used with hasIconOnly.`,
+      \n It is added to the left of the text criteria`,
       table: {
         defaultValue: { summary: "undefined" },
         type: { summary: "React.ReactNode" },
@@ -81,7 +80,6 @@ export default {
         "children",
         "icon",
         "onClick",
-        "hasIconOnly",
         "disabled",
         "size",
         "kind",

--- a/packages/design-system/src/stories/components/Button/Kind.stories.tsx
+++ b/packages/design-system/src/stories/components/Button/Kind.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  Box,
   Table,
   TableHead,
   TableRow,

--- a/packages/design-system/src/stories/components/ToggleButton/Basic.stories.tsx
+++ b/packages/design-system/src/stories/components/ToggleButton/Basic.stories.tsx
@@ -7,7 +7,7 @@ import {
   TableBody,
   TableCell,
 } from "@mui/material";
-import { Bell } from "@lunit/design-system-icons";
+import Bell from "@lunit/design-system-icons/Bell";
 import ToggleButton from "@/components/ToggleButton";
 import ToggleButtonGroup from "@/components/ToggleButtonGroup";
 
@@ -25,8 +25,7 @@ export default {
     icon: {
       control: false,
       description: `Use this prop when you want to add icon.
-        \n It is added to the left of the text criteria,
-        \n and only Icon can be checked when used with hasIconOnly.`,
+        \n It is added to the left of the text criteria`,
       table: {
         defaultValue: { summary: "undefined" },
         type: { summary: "React.ReactNode" },

--- a/packages/design-system/src/stories/components/ToggleButton/Group.stories.tsx
+++ b/packages/design-system/src/stories/components/ToggleButton/Group.stories.tsx
@@ -13,8 +13,7 @@ export default {
     icon: {
       control: false,
       description: `Use this prop when you want to add icon.
-        \n It is added to the left of the text criteria,
-        \n and only Icon can be checked when used with hasIconOnly.`,
+        \n It is added to the left of the text criteria`,
       table: {
         defaultValue: { summary: "undefined" },
         type: { summary: "React.ReactNode" },

--- a/packages/design-system/src/stories/components/ToggleButton/ToggleButtonKind.stories.tsx
+++ b/packages/design-system/src/stories/components/ToggleButton/ToggleButtonKind.stories.tsx
@@ -5,7 +5,6 @@ import {
   TableRow,
   TableBody,
   TableCell,
-  Typography,
 } from "@mui/material";
 import { action } from "@storybook/addon-actions";
 

--- a/packages/design-system/src/stories/components/ToggleButton/WithIcon.stories.tsx
+++ b/packages/design-system/src/stories/components/ToggleButton/WithIcon.stories.tsx
@@ -7,7 +7,7 @@ import {
   TableCell,
 } from "@mui/material";
 import { action } from "@storybook/addon-actions";
-import { Bell } from "@lunit/design-system-icons";
+import Bell from "@lunit/design-system-icons/Bell";
 
 import ToggleButton from "@/components/ToggleButton";
 
@@ -20,18 +20,10 @@ export default {
     icon: {
       control: false,
       description: `Use this prop when you want to add icon.
-        \n It is added to the left of the text criteria,
-        \n and only Icon can be checked when used with hasIconOnly.`,
+        \n It is added to the left of the text criteria`,
       table: {
         defaultValue: { summary: "undefined" },
         type: { summary: "React.ReactNode" },
-      },
-    },
-    hasIconOnly: {
-      description: `Option to handle so that only icons can be inserted
-          \n If set to false, you can add Text.`,
-      table: {
-        defaultValue: { summary: "false" },
       },
     },
     value: {


### PR DESCRIPTION
## Description

불필요한 hasIconOnly props type 에 대한 코드 및 내용을 삭제합니다.
트리쉐이킹을 위해 아이콘을 가져올 때 subPath 로 접근하여 해당 Icon 만 가져옵니다.

Button, ToggleButton 스토리북 정상 동작하는 것 확인했습니다.