### PR TITLE
Logo refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,4 @@ testem.log
 .DS_Store
 Thumbs.db
 
-# generated in logo
-packages/design-system-logo/src/components
-packages/design-system-logo/src/stories/logo
-
 .env.local

--- a/packages/design-system-logo/.gitignore
+++ b/packages/design-system-logo/.gitignore
@@ -1,0 +1,2 @@
+/src/generated
+/src/stories/logo

--- a/packages/design-system-logo/.npmignore
+++ b/packages/design-system-logo/.npmignore
@@ -1,0 +1,3 @@
+.storybook
+storybook-static
+src/stories

--- a/packages/design-system-logo/generator.mjs
+++ b/packages/design-system-logo/generator.mjs
@@ -9,6 +9,8 @@ import upperFirst from "lodash/upperFirst.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const outputPath = "src/generated";
+
 function getComponentName(name, grey, isDark) {
   let compoenentName = upperFirst(camelCase(name));
 
@@ -44,11 +46,11 @@ async function handler() {
     }),
   ]);
 
-  await fse.rm(path.join("src/components"), {
+  await fse.rm(path.join(outputPath), {
     recursive: true,
     force: true,
   });
-  await fse.mkdir(path.join("src/components"));
+  await fse.mkdir(path.join(outputPath));
 
   const logoList = [];
 
@@ -73,9 +75,9 @@ async function handler() {
       { componentName }
     );
 
-    await fse.mkdir(path.join("src/components", componentName));
+    await fse.mkdir(path.join(outputPath, componentName));
     await fse.writeFile(
-      path.join("src/components", componentName, "index.tsx"),
+      path.join(outputPath, componentName, "index.tsx"),
       componentString
     );
 
@@ -87,7 +89,7 @@ async function handler() {
 
   // make an index file
   const indexString = Mustache.render(indexTemplate, { logoList });
-  await fse.writeFile(path.join("src/components", "index.ts"), indexString);
+  await fse.writeFile(path.join(outputPath, "index.ts"), indexString);
 
   // make stories
   await fse.rm(path.join("src/stories/logo"), {

--- a/packages/design-system-logo/package.json
+++ b/packages/design-system-logo/package.json
@@ -2,9 +2,27 @@
   "name": "@lunit/design-system-logo",
   "version": "1.0.3",
   "description": "Lunit Design System Logo",
-  "main": "./index.js",
-  "types": "./index.d.ts",
+  "main": "dist/index.js",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*/index.d.ts",
+      "default": "./dist/*/index.js"
+    }
+  },
+  "types": "dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*/index.d.ts",
+        "dist/index.d.ts"
+      ]
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -15,12 +33,20 @@
     "test": "jest",
     "dev": "node ./generator.mjs && webpack --watch",
     "build": "node ./generator.mjs && webpack",
-    "postbuild": "cp package.json README.md favicon.mjs dist && cp -r ./src/assets/favicon dist",
-    "prepublishOnly": "[[ \"$PWD\" == *dist ]] || { exit 1; }",
     "storybook": "yarn build && storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
   "bin": "./favicon.mjs",
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/src/generated",
+          "{projectRoot}/dist"
+        ]
+      }
+    }
+  },
   "dependencies": {
     "chalk": "^5.0.1",
     "commander": "^9.4.0",

--- a/packages/design-system-logo/src/logo.stories.mustache
+++ b/packages/design-system-logo/src/logo.stories.mustache
@@ -1,6 +1,6 @@
 import React from "react";
 {{#logoList}}
-import {{componentName}}Logo from "../../components/{{componentName}}";
+import {{componentName}}Logo from "../../generated/{{componentName}}";
 {{/logoList}}
 
 export default {

--- a/packages/design-system-logo/webpack.config.js
+++ b/packages/design-system-logo/webpack.config.js
@@ -4,14 +4,14 @@ const nodeExternals = require("webpack-node-externals");
 
 module.exports = {
   mode: "production",
-  entry: glob.sync("./src/components/*/index.tsx").reduce(
+  entry: glob.sync("./src/generated/*/index.tsx").reduce(
     function (obj, el) {
-      const filePattern = /^.\/src\/components\/([a-zA-Z0-9_-]+)\/index.tsx/;
+      const filePattern = /^.\/src\/generated\/([a-zA-Z0-9_-]+)\/index.tsx/;
       const [_, name] = el.match(filePattern);
       obj[name] = el;
       return obj;
     },
-    { main: "./src/components/index.ts" }
+    { main: "./src/generated/index.ts" }
   ),
   output: {
     filename: (pathData) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "paths": {
       "@lunit/design-system": ["design-system/src"],
       "@lunit/design-system-icons": ["design-system-icons/src/generated"],
-      "@lunit/design-system-logo": ["design-system-logo/src"]
+      "@lunit/design-system-logo": ["design-system-logo/src/generated"]
     }
   }
 }


### PR DESCRIPTION
> #118 에 이어 작업했습니다.

`@lunit/design-system-logo` 패키지 구조를 업데이트합니다. `dist`로 `package.json`을 복사 후 `dist` 안에서 패키지를 배포하는 기존 방식 대신, 프로젝트 루트에서 그대로 배포하는 대신 각 컴포넌트의 경로를 `package.json`의 `exports` 필드에 지정하였습니다(icons와 같은 방식)

이번 변경사항으로 `nextjs-design-system`에서 `@lunit/design-system-logo`를 정상적으로 임포트하여 사용할 수 있게 되었습니다.
