### PR TITLE
[Fix] TextField wrong props type and style

### DIFF
--- a/packages/design-system/src/components/TextField/TextField.style.ts
+++ b/packages/design-system/src/components/TextField/TextField.style.ts
@@ -71,6 +71,9 @@ const getTextFieldPaddingBySize = ({
 };
 
 const commonStyle = ({ token }: { token: ColorToken }) => ({
+  "&.MuiTextField-root": {
+    width: "100%",
+  },
   "& .MuiOutlinedInput-root": {
     borderRadius: "8px",
     width: "100%",

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -11,7 +11,7 @@ import type {
 
 const SingleTextField = (props: SingleTextFieldProps) => {
   const {
-    size,
+    size = "small",
     leftIcon,
     rightIcon,
     leftIconSx,
@@ -48,7 +48,7 @@ const SingleTextField = (props: SingleTextFieldProps) => {
 };
 
 const MultiTextField = ({
-  size,
+  size = "small",
   onChange,
   ...restProps
 }: MultiTextFieldProps) => {
@@ -58,7 +58,7 @@ const MultiTextField = ({
 const TextField = (props: TextFieldProps) => {
   const {
     rows,
-    size = "small",
+    size,
     multiline = false,
     variant = "outlined",
     ...restProps

--- a/packages/design-system/src/components/TextField/TextField.types.ts
+++ b/packages/design-system/src/components/TextField/TextField.types.ts
@@ -10,7 +10,7 @@ export interface BaseTextFieldProps
   /**
    * The design system TextField variable is outlined fixed.
    */
-  variant: "outlined";
+  variant?: "outlined";
   value?: string;
   helperText?: string;
 
@@ -21,7 +21,6 @@ export interface BaseTextFieldProps
 }
 
 export interface SingleTextFieldProps extends BaseTextFieldProps {
-  size: TextFieldSize;
   leftIcon?: JSX.Element;
   rightIcon?: JSX.Element;
   leftIconSx?: SxProps;
@@ -32,7 +31,6 @@ export interface SingleTextFieldProps extends BaseTextFieldProps {
 
 export interface MultiTextFieldProps extends BaseTextFieldProps {
   rows?: number | string;
-  size: TextFieldSize;
 }
 
 export type TextFieldProps = SingleTextFieldProps | MultiTextFieldProps;


### PR DESCRIPTION
## Description

- `TextField` 에서 `size`, `variant` 가 필수값으로 지정된 버그를 수정합니다.
   위 수정사항을 통해 `TextField` 는 아무런 값을 넣지 않아도 동작합니다.
   
- `TextField` 사용 시, `width: 100%` 스타일을 지정해야 적용되는 버그를 수정합니다.
    이제 기본적으로 `width: 100%` 스타일이 지정됩니다.
    _([이슈 제보 PR](https://github.com/lunit-io/design-system/pull/121))_