### PR TITLE
[Fix] Button Component default kind Bug Fix

### DIFF
--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -39,6 +39,7 @@ export const sizeStyle = ({
         ? getIconButtonPaddingBySizeAndKind({ kind, size, selected })
         : getButtonPaddingBySizeAndKind({ kind, size, selected })
     }`,
+    minWidth: "28px",
     minHeight: "28px",
   }),
   ...(size === "medium" && {
@@ -48,6 +49,7 @@ export const sizeStyle = ({
         ? getIconButtonPaddingBySizeAndKind({ kind, size, selected })
         : getButtonPaddingBySizeAndKind({ kind, size, selected })
     }`,
+    minWidth: "36px",
     minHeight: "36px",
   }),
   ...(size === "large" && {
@@ -57,6 +59,7 @@ export const sizeStyle = ({
         ? getIconButtonPaddingBySizeAndKind({ kind, size, selected })
         : getButtonPaddingBySizeAndKind({ kind, size, selected })
     }`,
+    minWidth: "44px",
     minHeight: "44px",
   }),
 });
@@ -176,7 +179,6 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
 
 export const commonStyle = ({ token }: { token: ColorToken }) =>
   ({
-    minWidth: "auto",
     fontWeight: "500",
     borderRadius,
     textTransform: "initial",

--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -39,7 +39,6 @@ export const sizeStyle = ({
         ? getIconButtonPaddingBySizeAndKind({ kind, size, selected })
         : getButtonPaddingBySizeAndKind({ kind, size, selected })
     }`,
-    minWidth: "28px",
     minHeight: "28px",
   }),
   ...(size === "medium" && {
@@ -49,7 +48,6 @@ export const sizeStyle = ({
         ? getIconButtonPaddingBySizeAndKind({ kind, size, selected })
         : getButtonPaddingBySizeAndKind({ kind, size, selected })
     }`,
-    minWidth: "36px",
     minHeight: "36px",
   }),
   ...(size === "large" && {
@@ -59,7 +57,6 @@ export const sizeStyle = ({
         ? getIconButtonPaddingBySizeAndKind({ kind, size, selected })
         : getButtonPaddingBySizeAndKind({ kind, size, selected })
     }`,
-    minWidth: "44px",
     minHeight: "44px",
   }),
 });
@@ -179,6 +176,7 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
 
 export const commonStyle = ({ token }: { token: ColorToken }) =>
   ({
+    minWidth: "auto",
     fontWeight: "500",
     borderRadius,
     textTransform: "initial",

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -6,7 +6,6 @@ import type { ButtonProps } from "./Button.types";
 
 const Button = (props: ButtonProps) => {
   const {
-    kind = "contained",
     size = "small",
     color = "primary",
     icon,
@@ -21,25 +20,27 @@ const Button = (props: ButtonProps) => {
       {/** props.kind 사용 이유: props.color 내 타입 좁히기 활용을 위해 사용 */}
       {props.kind === "outlined" ? (
         <CustomButton
+          {...buttonProps}
           className={`outlined ${className ? className : ""}`}
           kind="outlined"
           color={props.color ?? "primary"}
           size={size}
           startIcon={icon}
           hasIconOnly={hasIconOnly}
-          {...buttonProps}
         >
           {!hasIconOnly && <>{children}</>}
         </CustomButton>
       ) : (
         <CustomButton
-          className={`${props.kind} ${className ? className : ""}`}
-          kind={props.kind}
-          color={color}
+          {...buttonProps}
+          className={`${props.kind ?? "contained"} ${
+            className ? className : ""
+          }`}
+          kind={props.kind ?? "contained"}
+          color={props.color ?? "primary"}
           size={size}
           startIcon={icon}
           hasIconOnly={hasIconOnly}
-          {...buttonProps}
         >
           {!hasIconOnly && <>{children}</>}
         </CustomButton>


### PR DESCRIPTION
## Description

- `Button` 에서 default kind 가 `contained` 로 지정되지 않는 이슈를 해결합니다.

- 버그가 발생한 원인은 다음과 같습니다.
   - default parameter 를 적용한 부분은 구조분해할당된 kind 였으나,
      실제 CustomButton 의 kind props 로 넘겨준 value 는 props.kind 즉 default parameter 가
      적용되지 않은 값을 넘겨주었습니다.

      이로 인해, Mui Button 의 default value 인 [`text(ghost)`](https://mui.com/material-ui/react-button/#basic-button) 가 적용되어 버그가 발생했습니다.

- 버그 해결 방식은 다음과 같습니다.
   - props.kind 의 값이 없을 때 넣어줄 값을 props 로 넘겨줄 때 진행합니다. [bcedd80](https://github.com/lunit-io/design-system/pull/125/commits/bcedd80da71feb75c07789adb0cdc8f796300442)
   
  