### PR TITLE
[DS-76] color token hierarchy 수정 + 컴포넌트 내 color token 수정

### DIFF
--- a/apps/nextjs-test-system/components/MainBoard.tsx
+++ b/apps/nextjs-test-system/components/MainBoard.tsx
@@ -69,9 +69,9 @@ function MainBoard() {
         sx={{
           padding: "0.25rem 1.25rem",
           borderRadius: "0.75rem",
-          backgroundColor: theme.palette.token.core.bg_01,
+          backgroundColor: theme.palette.lunit_token.core.bg_01,
           marginBottom: "1.5rem",
-          color: theme.palette.token.core.text_normal,
+          color: theme.palette.lunit_token.core.text_normal,
           typography: "body2_14_regular",
         }}
       >
@@ -110,7 +110,7 @@ function MainBoard() {
           },
           "&::-webkit-scrollbar-thumb": {
             borderRadius: "0.375rem",
-            background: theme.palette.token.component.scrollbars_bg,
+            background: theme.palette.lunit_token.component.scrollbars_bg,
           },
         }}
       >

--- a/apps/nextjs-test-system/components/SidePanel.tsx
+++ b/apps/nextjs-test-system/components/SidePanel.tsx
@@ -45,7 +45,7 @@ function SidePanel() {
       component="form"
       sx={{
         flex: "0 0 500px",
-        backgroundColor: theme.palette.token.core.bg_03,
+        backgroundColor: theme.palette.lunit_token.core.bg_03,
         display: "flex",
         flexDirection: "column",
         gap: "1.25rem",
@@ -57,10 +57,10 @@ function SidePanel() {
         },
         "&::-webkit-scrollbar-thumb": {
           borderRadius: "0.375rem",
-          background: theme.palette.token.component.scrollbars_bg,
+          background: theme.palette.lunit_token.component.scrollbars_bg,
         },
         borderLeft: "1px solid #000",
-        color: theme.palette.token.core.text_normal,
+        color: theme.palette.lunit_token.core.text_normal,
       }}
     >
       <Box sx={{ display: "flex" }}>

--- a/apps/nextjs-test-system/pages/_app.tsx
+++ b/apps/nextjs-test-system/pages/_app.tsx
@@ -14,7 +14,7 @@ export default function App({ Component, pageProps }: AppProps) {
         maxWidth={false}
         disableGutters
         sx={{
-          backgroundColor: theme.palette.token.core.bg_01,
+          backgroundColor: theme.palette.lunit_token.core.bg_01,
           height: "100vh",
           overflow: "hidden",
         }}

--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -11,8 +11,8 @@ export const decorators = [
         <CssBaseline />
         <Box
           className={surface}
-          bgcolor={theme.palette.token.core.bg_01}
-          color={theme.palette.token.core.text_normal}
+          bgcolor={theme.palette.lunit_token.core.bg_01}
+          color={theme.palette.lunit_token.core.text_normal}
           sx={{ p: 2 }}
         >
           <Story />

--- a/packages/design-system/src/components/Alert/Alert.styled.ts
+++ b/packages/design-system/src/components/Alert/Alert.styled.ts
@@ -50,12 +50,12 @@ export const StyledAlertTitle = styled(MuiAlertTitle)(({ theme }) => ({
     fontWeight: 700,
     fontSize: "14px",
     lineHeight: "20px",
-    color: theme.palette.token.core.text_normal,
+    color: theme.palette.lunit_token.core.text_normal,
   },
 }));
 
 export const StyledAlertChildren = styled("div")(({ theme }) => ({
-  color: theme.palette.token.core.text_normal,
+  color: theme.palette.lunit_token.core.text_normal,
 }));
 
 export const StyledBottomAction = styled("div")({

--- a/packages/design-system/src/components/Alert/Alert.utils.ts
+++ b/packages/design-system/src/components/Alert/Alert.utils.ts
@@ -6,13 +6,13 @@ export const getBackgroundColor = (
 ) => {
   switch (severity) {
     case "info":
-      return theme.palette.token.component.alert_info_bg;
+      return theme.palette.lunit_token.component.alert_info_bg;
     case "warning":
-      return theme.palette.token.component.alert_warning_bg;
+      return theme.palette.lunit_token.component.alert_warning_bg;
     case "error":
-      return theme.palette.token.component.alert_error_bg;
+      return theme.palette.lunit_token.component.alert_error_bg;
     default:
-      return theme.palette.token.component.alert_success_bg;
+      return theme.palette.lunit_token.component.alert_success_bg;
   }
 };
 
@@ -22,13 +22,13 @@ export const getBorderColor = (
 ) => {
   switch (severity) {
     case "info":
-      return theme.palette.token.component.alert_info_border;
+      return theme.palette.lunit_token.component.alert_info_border;
     case "warning":
-      return theme.palette.token.component.alert_warning_border;
+      return theme.palette.lunit_token.component.alert_warning_border;
     case "error":
-      return theme.palette.token.component.alert_error_border;
+      return theme.palette.lunit_token.component.alert_error_border;
     default:
-      return theme.palette.token.component.alert_success_border;
+      return theme.palette.lunit_token.component.alert_success_border;
   }
 };
 
@@ -38,12 +38,12 @@ export const getIconColor = (
 ) => {
   switch (severity) {
     case "info":
-      return theme.palette.token.core.icon_info_02;
+      return theme.palette.lunit_token.core.icon_info_02;
     case "warning":
-      return theme.palette.token.core.icon_warning_02;
+      return theme.palette.lunit_token.core.icon_warning_02;
     case "error":
-      return theme.palette.token.core.icon_error_02;
+      return theme.palette.lunit_token.core.icon_error_02;
     default:
-      return theme.palette.token.core.icon_success_02;
+      return theme.palette.lunit_token.core.icon_success_02;
   }
 };

--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -12,7 +12,7 @@ import type { ToggleButtonProps } from "../ToggleButton/ToggleButton.types";
 import type { Typography } from "@mui/material/styles/createTypography";
 
 type KindStyleParams = Pick<ButtonProps, "kind" | "color"> & {
-  token: ColorToken;
+  lunit_token: ColorToken;
 };
 
 type CustomButtonProps = ButtonProps & { hasIconOnly: boolean };
@@ -64,79 +64,79 @@ export const sizeStyle = ({
   }),
 });
 
-export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
+export const kindStyle = ({ kind, color, lunit_token }: KindStyleParams) => ({
   // kind: container
   ...(kind === "contained" &&
     color === "primary" && {
-      color: token.component.btn_primary_text_2,
-      backgroundColor: token.component.btn_primary_bg,
-      "&:hover": getHoverStyle(token.component.btn_primary_bg),
+      color: lunit_token.component.btn_primary_text_2,
+      backgroundColor: lunit_token.component.btn_primary_bg,
+      "&:hover": getHoverStyle(lunit_token.component.btn_primary_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
-        color: token.component.btn_primary_text_2,
+        color: lunit_token.component.btn_primary_text_2,
       },
     }),
   ...(kind === "contained" &&
     color === "secondary" && {
-      color: token.component.btn_secondary_text,
-      backgroundColor: token.component.btn_secondary_bg,
-      "&:hover": getHoverStyle(token.component.btn_secondary_bg),
+      color: lunit_token.component.btn_secondary_text,
+      backgroundColor: lunit_token.component.btn_secondary_bg,
+      "&:hover": getHoverStyle(lunit_token.component.btn_secondary_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
-        color: token.component.btn_secondary_text,
+        color: lunit_token.component.btn_secondary_text,
       },
     }),
   ...(kind === "contained" &&
     color === "error" && {
-      color: token.component.btn_primary_text_2,
-      backgroundColor: token.component.btn_error_bg,
-      "&:hover": getHoverStyle(token.component.btn_error_bg),
+      color: lunit_token.component.btn_primary_text_2,
+      backgroundColor: lunit_token.component.btn_error_bg,
+      "&:hover": getHoverStyle(lunit_token.component.btn_error_bg),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
-        color: token.component.btn_primary_text_2,
+        color: lunit_token.component.btn_primary_text_2,
       },
     }),
   // kind: ghost
   ...(kind === "ghost" &&
     color === "primary" && {
-      color: token.component.btn_primary_text_1,
+      color: lunit_token.component.btn_primary_text_1,
       border: "none",
       "&:hover": getHoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
-        color: token.component.btn_primary_text_1,
+        color: lunit_token.component.btn_primary_text_1,
       },
     }),
   ...(kind === "ghost" &&
     color === "secondary" && {
-      color: token.component.btn_secondary_text,
+      color: lunit_token.component.btn_secondary_text,
       border: "none",
       "&:hover": getHoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
-        color: token.component.btn_secondary_text,
+        color: lunit_token.component.btn_secondary_text,
       },
     }),
   ...(kind === "ghost" &&
     color === "error" && {
-      color: token.component.btn_error_text,
+      color: lunit_token.component.btn_error_text,
       "&:hover": getHoverStyle("none"),
       "&.Mui-disabled": {
         opacity: 0.38,
         border: "none",
-        color: token.component.btn_error_text,
+        color: lunit_token.component.btn_error_text,
       },
     }),
   // kind: outlined
   ...(kind === "outlined" &&
     color === "primary" && {
-      color: token.component.btn_primary_text_1,
-      border: `${OUTLINED_BORDER_WIDTH}px solid ${token.component.btn_primary_border}`,
+      color: lunit_token.component.btn_primary_text_1,
+      border: `${OUTLINED_BORDER_WIDTH}px solid ${lunit_token.component.btn_primary_border}`,
       "&:hover": getHoverStyle("none"),
       "&:hover:before": {
         content: "''",
@@ -146,18 +146,18 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
         width: "calc(100% + 2px)",
         height: "calc(100% + 2px)",
         zIndex: -1,
-        backgroundColor: token.core.hover,
+        backgroundColor: lunit_token.core.hover,
         borderRadius,
       },
       "&.Mui-disabled": {
         opacity: 0.38,
-        color: token.component.btn_primary_text_1,
+        color: lunit_token.component.btn_primary_text_1,
       },
     }),
   ...(kind === "outlined" &&
     color === "secondary" && {
-      color: token.component.btn_secondary_text,
-      border: `${OUTLINED_BORDER_WIDTH}px solid ${token.component.btn_secondary_border}`,
+      color: lunit_token.component.btn_secondary_text,
+      border: `${OUTLINED_BORDER_WIDTH}px solid ${lunit_token.component.btn_secondary_border}`,
       "&:hover": getHoverStyle("none"),
       "&:hover:before": {
         content: "''",
@@ -167,17 +167,17 @@ export const kindStyle = ({ kind, color, token }: KindStyleParams) => ({
         width: "calc(100% + 2px)",
         height: "calc(100% + 2px)",
         zIndex: -1,
-        backgroundColor: token.core.hover,
+        backgroundColor: lunit_token.core.hover,
         borderRadius,
       },
       "&.Mui-disabled": {
         opacity: 0.38,
-        color: token.component.btn_secondary_text,
+        color: lunit_token.component.btn_secondary_text,
       },
     }),
 });
 
-export const commonStyle = ({ token }: { token: ColorToken }) =>
+export const commonStyle = ({ lunit_token }: { lunit_token: ColorToken }) =>
   ({
     fontWeight: "500",
     borderRadius,
@@ -189,7 +189,7 @@ export const commonStyle = ({ token }: { token: ColorToken }) =>
         height: `calc(100% + ${PADDING_OF_FOCUS}px)`,
         content: '""',
         borderRadius: "11px",
-        border: `1px solid ${token.core.focused}`,
+        border: `1px solid ${lunit_token.core.focused}`,
         boxSizing: "border-box",
       },
     },
@@ -201,7 +201,7 @@ export const commonStyle = ({ token }: { token: ColorToken }) =>
       width: "100%",
       height: "100%",
       zIndex: -1,
-      backgroundColor: token.core.hover,
+      backgroundColor: lunit_token.core.hover,
       borderRadius,
     },
   } as const);
@@ -237,16 +237,16 @@ export const CustomButton = styled(MuiButton, {
   ({
     theme: {
       typography,
-      palette: { token },
+      palette: { lunit_token },
     },
     kind,
     size,
     color,
     hasIconOnly,
   }) => ({
-    ...commonStyle({ token }),
+    ...commonStyle({ lunit_token }),
     ...iconStyle({ size, hasIconOnly }),
     ...sizeStyle({ size, kind, hasIconOnly, typography }),
-    ...kindStyle({ kind, color, token }),
+    ...kindStyle({ kind, color, lunit_token }),
   })
 );

--- a/packages/design-system/src/components/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Checkbox/Checkbox.tsx
@@ -15,7 +15,7 @@ const CustomCheckbox = styled(MuiCheckbox)(({ theme }) => ({
     position: "absolute",
     width: 24,
     height: 24,
-    border: `1px solid ${theme.palette.token.core.focused}`,
+    border: `1px solid ${theme.palette.lunit_token.core.focused}`,
     borderRadius: "7px",
   },
 }));
@@ -27,7 +27,7 @@ const iconSize = {
 
 const DefaultIcon = styled("span")(({ theme }) => ({
   ...iconSize,
-  backgroundColor: theme.palette.token.component.selectcontrol_off,
+  backgroundColor: theme.palette.lunit_token.component.selectcontrol_off,
   maskImage:
     "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath" +
     " fill-rule='evenodd' clip-rule='evenodd' d='M14 1.5H4C2.61929 1.5 1.5 2.61929 1.5 4V14C1.5 15.3807 2.61929 16.5 4 16.5H14C15.3807 " +
@@ -36,7 +36,7 @@ const DefaultIcon = styled("span")(({ theme }) => ({
 
 const CheckedIcon = styled("span")(({ theme }) => ({
   ...iconSize,
-  backgroundColor: theme.palette.token.component.selectcontrol_on,
+  backgroundColor: theme.palette.lunit_token.component.selectcontrol_on,
   maskImage:
     "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath" +
     " fill-rule='evenodd' clip-rule='evenodd' d='M4 0C1.79086 0 0 1.79086 0 4V14C0 16.2091 1.79086 18 4 18H14C16.2091 18 18 16.2091 18 14V4C18 1.79086 16.2091 0 14 0H4ZM14.2516 " +
@@ -45,7 +45,7 @@ const CheckedIcon = styled("span")(({ theme }) => ({
 
 const IndeterminateIcon = styled("span")(({ theme }) => ({
   ...iconSize,
-  backgroundColor: theme.palette.token.component.selectcontrol_on,
+  backgroundColor: theme.palette.lunit_token.component.selectcontrol_on,
   maskImage:
     "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18'%3E%3Cpath" +
     " fill-rule='evenodd' clip-rule='evenodd' d='M4 0C1.79086 0 0 1.79086 0 4V14C0 16.2091 1.79086 18 4 18H14C16.2091 18 18 16.2091 18 14V4C18 1.79086 16.2091 0 " +

--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -36,32 +36,32 @@ const getColorToken = (
   if (token === "text") {
     switch (color) {
       case CHIP_COLORS.PRIMARY:
-        return theme.palette.token.component.chip_primary_text;
+        return theme.palette.lunit_token.component.chip_primary_text;
       case CHIP_COLORS.SECONDARY:
-        return theme.palette.token.component.chip_secondary_text;
+        return theme.palette.lunit_token.component.chip_secondary_text;
       case CHIP_COLORS.ERROR:
-        return theme.palette.token.component.chip_error_text;
+        return theme.palette.lunit_token.component.chip_error_text;
       case CHIP_COLORS.WARNING:
-        return theme.palette.token.component.chip_warning_text;
+        return theme.palette.lunit_token.component.chip_warning_text;
       case CHIP_COLORS.SUCCESS:
-        return theme.palette.token.component.chip_success_text;
+        return theme.palette.lunit_token.component.chip_success_text;
       default:
-        return theme.palette.token.component.chip_primary_text;
+        return theme.palette.lunit_token.component.chip_primary_text;
     }
   } else {
     switch (color) {
       case CHIP_COLORS.PRIMARY:
-        return theme.palette.token.component.chip_primary_bg;
+        return theme.palette.lunit_token.component.chip_primary_bg;
       case CHIP_COLORS.SECONDARY:
-        return theme.palette.token.component.chip_secondary_bg;
+        return theme.palette.lunit_token.component.chip_secondary_bg;
       case CHIP_COLORS.ERROR:
-        return theme.palette.token.component.chip_error_bg;
+        return theme.palette.lunit_token.component.chip_error_bg;
       case CHIP_COLORS.WARNING:
-        return theme.palette.token.component.chip_warning_bg;
+        return theme.palette.lunit_token.component.chip_warning_bg;
       case CHIP_COLORS.SUCCESS:
-        return theme.palette.token.component.chip_success_bg;
+        return theme.palette.lunit_token.component.chip_success_bg;
       default:
-        return theme.palette.token.component.chip_primary_bg;
+        return theme.palette.lunit_token.component.chip_primary_bg;
     }
   }
 };
@@ -82,7 +82,7 @@ export const StyledContainedChipBase = styled(MuiChip, {
   ...COMMON_STYLES,
   ...theme.typography.caption,
 
-  color: theme.palette.token.core.text_normal,
+  color: theme.palette.lunit_token.core.text_normal,
   backgroundColor: getColorToken("bg", theme, color),
 
   "& .MuiSvgIcon-root": {
@@ -134,7 +134,7 @@ export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
     left: 0,
     right: 0,
     bottom: 0,
-    backgroundColor: theme.palette.token.core.hover,
+    backgroundColor: theme.palette.lunit_token.core.hover,
     borderRadius: "11px",
   },
 }));
@@ -155,7 +155,7 @@ export const StyledContainedChipDeletable = styled(
     right: 0,
     bottom: 0,
     opacity: 0,
-    color: theme.palette.token.core.hover,
+    color: theme.palette.lunit_token.core.hover,
     ":hover": {
       cursor: "pointer",
       opacity: 1,

--- a/packages/design-system/src/components/Radio/Radio.tsx
+++ b/packages/design-system/src/components/Radio/Radio.tsx
@@ -13,7 +13,7 @@ const CustomRadio = styled(MuiRadio)(({ theme }) => ({
     display: "block",
     width: 24,
     height: 24,
-    backgroundColor: theme.palette.token.core.focused,
+    backgroundColor: theme.palette.lunit_token.core.focused,
     maskImage:
       "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath" +
       " fill-rule='evenodd' clip-rule='evenodd' d='M12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23ZM12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 " +
@@ -28,7 +28,7 @@ const iconSize = {
 
 const DefaultIcon = styled("span")(({ theme }) => ({
   ...iconSize,
-  backgroundColor: theme.palette.token.component.selectcontrol_off,
+  backgroundColor: theme.palette.lunit_token.component.selectcontrol_off,
   maskImage:
     "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath" +
     " fill-rule='evenodd' clip-rule='evenodd' d='M10 17.5C14.1421 17.5 17.5 14.1421 17.5 10C17.5 5.85786 14.1421 2.5 10 2.5C5.85786 2.5 2.5 5.85786 2.5 10C2.5 14.1421 5.85786 17.5 " +
@@ -37,7 +37,7 @@ const DefaultIcon = styled("span")(({ theme }) => ({
 
 const CheckedIcon = styled("span")(({ theme }) => ({
   ...iconSize,
-  backgroundColor: theme.palette.token.component.selectcontrol_on,
+  backgroundColor: theme.palette.lunit_token.component.selectcontrol_on,
   maskImage:
     "url(\"data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath" +
     " fill-rule='evenodd' clip-rule='evenodd' d='M10 15C12.7614 15 15 12.7614 15 10C15 7.23858 12.7614 5 10 5C7.23858 5 5" +

--- a/packages/design-system/src/components/TextField/TextField.style.ts
+++ b/packages/design-system/src/components/TextField/TextField.style.ts
@@ -70,7 +70,7 @@ const getTextFieldPaddingBySize = ({
       });
 };
 
-const commonStyle = ({ token }: { token: ColorToken }) => ({
+const commonStyle = ({ lunit_token }: { lunit_token: ColorToken }) => ({
   "&.MuiTextField-root": {
     width: "100%",
   },
@@ -82,24 +82,24 @@ const commonStyle = ({ token }: { token: ColorToken }) => ({
       border: "none",
     },
     "&.Mui-error fieldset": {
-      border: `1px solid ${token.component.textfield_border_error}`,
+      border: `1px solid ${lunit_token.component.textfield_border_error}`,
     },
     "&.Mui-focused fieldset": {
-      border: `1px solid ${token.core.focused}`,
+      border: `1px solid ${lunit_token.core.focused}`,
     },
     "&.Mui-disabled": {
       opacity: 0.38,
       "&:hover::before": {
-        backgroundColor: token.component.textfield_bg,
+        backgroundColor: lunit_token.component.textfield_bg,
       },
     },
     "& input, textarea": {
       padding: 0,
       textOverflow: "ellipsis",
       "&::placeholder": {
-        color: token.core.text_medium,
+        color: lunit_token.core.text_medium,
         opacity: 1,
-        WebkitTextFillColor: token.core.text_medium,
+        WebkitTextFillColor: lunit_token.core.text_medium,
       },
     },
     "& textarea": {
@@ -110,16 +110,16 @@ const commonStyle = ({ token }: { token: ColorToken }) => ({
       },
       "&::-webkit-scrollbar-thumb": {
         borderRadius: "6px",
-        backgroundColor: token.component.scrollbars_bg,
+        backgroundColor: lunit_token.component.scrollbars_bg,
       },
     },
-    background: token.component.textfield_bg,
+    background: lunit_token.component.textfield_bg,
     overflow: "hidden",
-    color: token.core.text_normal,
+    color: lunit_token.core.text_normal,
     "&:hover": {
       position: "relative",
       zIndex: 0,
-      backgroundColor: token.component.textfield_bg,
+      backgroundColor: lunit_token.component.textfield_bg,
     },
     "&:hover::before": {
       content: '""',
@@ -129,11 +129,11 @@ const commonStyle = ({ token }: { token: ColorToken }) => ({
       width: "100%",
       height: "100%",
       zIndex: -1,
-      backgroundColor: token.core.hover,
+      backgroundColor: lunit_token.core.hover,
     },
     "&.Mui-focused": {
       "&:hover::before": {
-        backgroundColor: token.component.textfield_bg,
+        backgroundColor: lunit_token.component.textfield_bg,
       },
     },
   },
@@ -142,13 +142,13 @@ const commonStyle = ({ token }: { token: ColorToken }) => ({
       opacity: 0.38,
     },
     "&.Mui-error": {
-      color: token.core.text_error,
+      color: lunit_token.core.text_error,
     },
   },
 });
 
 const sizeStyle = ({
-  token,
+  lunit_token,
   textFieldSize,
   hasLeftIcon,
   hasRightIcon,
@@ -157,7 +157,7 @@ const sizeStyle = ({
 }: Pick<
   BaseTextFieldProps,
   "textFieldSize" | "hasLeftIcon" | "hasRightIcon" | "multiline"
-> & { token: ColorToken; typography: Typography }) => ({
+> & { lunit_token: ColorToken; typography: Typography }) => ({
   ...(textFieldSize === "small" && {
     "& .MuiInputBase-root": {
       padding: getTextFieldPaddingBySize({
@@ -179,17 +179,17 @@ const sizeStyle = ({
     },
     "& .MuiFormHelperText-root": {
       ...typography.body2_14_regular,
-      color: token.core.text_medium,
+      color: lunit_token.core.text_medium,
       margin: 0,
       marginTop: "4px",
       paddingLeft: "4px",
 
       "&.Mui-disabled": {
-        color: token.core.text_medium,
+        color: lunit_token.core.text_medium,
         opacity: 0.38,
       },
       "&.Mui-error": {
-        color: token.core.text_error,
+        color: lunit_token.core.text_error,
       },
     },
   }),
@@ -214,17 +214,17 @@ const sizeStyle = ({
     },
     "& .MuiFormHelperText-root": {
       ...typography.body2_14_regular,
-      color: token.core.text_medium,
+      color: lunit_token.core.text_medium,
       margin: 0,
       marginTop: "4px",
       paddingLeft: "4px",
 
       "&.Mui-disabled": {
-        color: token.core.text_medium,
+        color: lunit_token.core.text_medium,
         opacity: 0.38,
       },
       "&.Mui-error": {
-        color: token.core.text_error,
+        color: lunit_token.core.text_error,
       },
     },
   }),
@@ -249,17 +249,17 @@ const sizeStyle = ({
     },
     "& .MuiFormHelperText-root": {
       ...typography.body1_16_regular,
-      color: token.core.text_medium,
+      color: lunit_token.core.text_medium,
       margin: 0,
       marginTop: "4px",
       paddingLeft: "4px",
 
       "&.Mui-disabled": {
-        color: token.core.text_medium,
+        color: lunit_token.core.text_medium,
         opacity: 0.38,
       },
       "&.Mui-error": {
-        color: token.core.text_error,
+        color: lunit_token.core.text_error,
       },
     },
   }),
@@ -282,16 +282,16 @@ const BaseTextField = styled(MuiTextField, {
   ({
     theme: {
       typography,
-      palette: { token },
+      palette: { lunit_token },
     },
     multiline,
     textFieldSize,
     hasLeftIcon,
     hasRightIcon,
   }) => ({
-    ...commonStyle({ token }),
+    ...commonStyle({ lunit_token }),
     ...sizeStyle({
-      token,
+      lunit_token,
       textFieldSize,
       hasLeftIcon,
       hasRightIcon,
@@ -312,7 +312,7 @@ const IconWrapper = styled("div")(({ theme }) => ({
   "& svg": {
     width: "20px",
     height: "20px",
-    color: theme.palette.token.core.text_normal,
+    color: theme.palette.lunit_token.core.text_normal,
   },
 }));
 

--- a/packages/design-system/src/components/Toast/Toast.styled.ts
+++ b/packages/design-system/src/components/Toast/Toast.styled.ts
@@ -10,8 +10,8 @@ export const StyledToast = styled(Alert)(({ theme, severity }) => {
     "&.MuiAlert-root": {
       padding: "8px 16px 8px 16px",
       margin: 0,
-      color: theme.palette.token.core.text_normal,
-      backgroundColor: theme.palette.token.core.bg_03,
+      color: theme.palette.lunit_token.core.text_normal,
+      backgroundColor: theme.palette.lunit_token.core.bg_03,
       borderRadius: "8px",
     },
     "& .MuiAlert-icon": {
@@ -42,7 +42,7 @@ export const StyledToast = styled(Alert)(({ theme, severity }) => {
       marginRight: "0px",
       padding: 0,
       "& .MuiSvgIcon-root": {
-        color: theme.palette.token.core.text_normal,
+        color: theme.palette.lunit_token.core.text_normal,
       },
     },
   };

--- a/packages/design-system/src/components/Toast/Toast.utils.ts
+++ b/packages/design-system/src/components/Toast/Toast.utils.ts
@@ -6,12 +6,12 @@ export const getIconColor = (
 ) => {
   switch (severity) {
     case "info":
-      return theme.palette.token.core.icon_info_02;
+      return theme.palette.lunit_token.core.icon_info_02;
     case "warning":
-      return theme.palette.token.core.icon_warning_02;
+      return theme.palette.lunit_token.core.icon_warning_02;
     case "error":
-      return theme.palette.token.core.icon_error_02;
+      return theme.palette.lunit_token.core.icon_error_02;
     default:
-      return theme.palette.token.core.icon_success_02;
+      return theme.palette.lunit_token.core.icon_success_02;
   }
 };

--- a/packages/design-system/src/components/Toggle/Toggle.styled.ts
+++ b/packages/design-system/src/components/Toggle/Toggle.styled.ts
@@ -1,6 +1,6 @@
 import { styled, Switch as MuiSwitch, SwitchProps } from "@mui/material";
 interface ToggleProps extends SwitchProps {
-  toggleSize: 'medium' | 'large'
+  toggleSize: "medium" | "large";
 }
 
 const toggleStyles = {
@@ -19,15 +19,15 @@ const toggleStyles = {
       transition: "all 100ms ease-in-out",
     },
     switchChecked: {
-      transform: 'translateX(10px)',
+      transform: "translateX(10px)",
     },
     thumb: {
-        width: 14,
-        height: 14,
-    }
+      width: 14,
+      height: 14,
+    },
   },
   large: {
-    root:{
+    root: {
       width: 44,
       height: 24,
       borderRadius: 12,
@@ -41,20 +41,20 @@ const toggleStyles = {
       transition: "all 150ms ease-in-out",
     },
     switchChecked: {
-      transform: 'translateX(20px)',
+      transform: "translateX(20px)",
     },
     thumb: {
       width: 20,
       height: 20,
     },
   },
-}
+};
 
 const indeterminateStyles = {
   large: {
     switchChecked: {
-        top: 8,
-        left: -8,
+      top: 8,
+      left: -8,
     },
     track: {
       borderRadius: 12,
@@ -67,8 +67,8 @@ const indeterminateStyles = {
   },
   medium: {
     switchChecked: {
-        top: 6,
-        left: -4,
+      top: 6,
+      left: -4,
     },
     track: {
       borderRadius: 12,
@@ -78,28 +78,29 @@ const indeterminateStyles = {
       width: 12,
       borderRadius: 2,
     },
-  }
-}
+  },
+};
 
 export const CommonToggle = styled(MuiSwitch, {
-  shouldForwardProp: (props) => props !== 'toggleSize',
+  shouldForwardProp: (props) => props !== "toggleSize",
 })<ToggleProps>(({ theme, toggleSize, disabled }) => {
-  const checkedColor = theme.palette.token.component.selectcontrol_on;
-  const uncheckedColor = theme.palette.token.component.selectcontrol_off;
-  const handlerColor = theme.palette.token.component.selectcontrol_handler;
+  const checkedColor = theme.palette.lunit_token.component.selectcontrol_on;
+  const uncheckedColor = theme.palette.lunit_token.component.selectcontrol_off;
+  const handlerColor =
+    theme.palette.lunit_token.component.selectcontrol_handler;
 
   const toggleStyle = toggleStyles[toggleSize];
   const toggleOpacity = disabled ? 0.38 : 1;
 
   return {
     ...toggleStyle.root,
-    display: 'flex',
+    display: "flex",
     padding: 0,
     overflow: "visible",
     backgroundColor: "transparent",
     opacity: toggleOpacity,
     "& .Mui-focusVisible": {
-       // clear default focus style
+      // clear default focus style
       boxShadow: "none",
       background: "transparent",
       borderColor: "transparent",
@@ -112,51 +113,53 @@ export const CommonToggle = styled(MuiSwitch, {
         boxSizing: "border-box",
         top: -3, // border 1px + offset 2px
         left: -3, // border 1px + offset 2px
-      }
+      },
     },
-    '& .MuiSwitch-track': {
+    "& .MuiSwitch-track": {
       opacity: 1,
       borderRadius: 12,
       backgroundColor: uncheckedColor,
     },
-    '& .MuiSwitch-thumb': {
+    "& .MuiSwitch-thumb": {
       ...toggleStyle.thumb,
       boxShadow: "0px 0px 1px rgba(0, 0, 0, 0.4)",
     },
-    '& .MuiSwitch-switchBase': {
+    "& .MuiSwitch-switchBase": {
       ...toggleStyle.switch,
       padding: 2,
       opacity: 1,
-      '&.Mui-checked': {
+      "&.Mui-checked": {
         ...toggleStyle.switchChecked,
         color: handlerColor,
-        '& + .MuiSwitch-track': {
+        "& + .MuiSwitch-track": {
           opacity: 1,
           backgroundColor: checkedColor,
         },
       },
     },
-    '& .Mui-disabled + .MuiSwitch-track': {
+    "& .Mui-disabled + .MuiSwitch-track": {
       opacity: 1,
     },
-  }});
+  };
+});
 
 export const CommonIndeterminateToggle = styled(CommonToggle, {
-  shouldForwardProp: (props) => props !== 'toggleSize',
+  shouldForwardProp: (props) => props !== "toggleSize",
 })(({ toggleSize }) => {
   const indeterminateStyle = indeterminateStyles[toggleSize];
 
   return {
-  padding: 0,
-  cursor: "pointer",
-  '& .MuiSwitch-switchBase.Mui-checked': {
+    padding: 0,
+    cursor: "pointer",
+    "& .MuiSwitch-switchBase.Mui-checked": {
       ...indeterminateStyle.switchChecked,
-      '& + .MuiSwitch-track': {
+      "& + .MuiSwitch-track": {
         ...indeterminateStyle.track,
+      },
     },
-  },
-  '& .MuiSwitch-thumb': {
-    ...indeterminateStyle.thumb,
-    boxShadow: "none",
-  },
-}});
+    "& .MuiSwitch-thumb": {
+      ...indeterminateStyle.thumb,
+      boxShadow: "none",
+    },
+  };
+});

--- a/packages/design-system/src/components/ToggleButton/ToggleButton.styled.ts
+++ b/packages/design-system/src/components/ToggleButton/ToggleButton.styled.ts
@@ -19,7 +19,7 @@ export const CustomToggleButton = styled(MuiToggleButton, {
   ({
     theme: {
       typography,
-      palette: { token },
+      palette: { lunit_token },
     },
     kind,
     size,
@@ -30,22 +30,22 @@ export const CustomToggleButton = styled(MuiToggleButton, {
   }) => {
     return {
       border: "none",
-      ...commonStyle({ token }),
+      ...commonStyle({ lunit_token }),
       ...iconStyle({ size, hasIconOnly }),
       ...sizeStyle({ size, kind, hasIconOnly, selected, typography }),
-      ...kindStyle({ kind, color, token }),
+      ...kindStyle({ kind, color, lunit_token }),
       ...(selectedColor === "primary" && {
         "&.Mui-selected, &.Mui-selected:hover": {
           border: "none",
-          backgroundColor: token.component.btn_selected_primary_bg,
-          color: token.component.btn_selected_primary_text,
+          backgroundColor: lunit_token.component.btn_selected_primary_bg,
+          color: lunit_token.component.btn_selected_primary_text,
         },
       }),
       ...(selectedColor === "secondary" && {
         "&.Mui-selected, &.Mui-selected:hover": {
           border: "none",
-          backgroundColor: token.component.btn_selected_secondary_bg,
-          color: token.component.btn_selected_secondary_text,
+          backgroundColor: lunit_token.component.btn_selected_secondary_bg,
+          color: lunit_token.component.btn_selected_secondary_text,
         },
       }),
     };

--- a/packages/design-system/src/foundation/Elevation/index.ts
+++ b/packages/design-system/src/foundation/Elevation/index.ts
@@ -2,10 +2,10 @@ import paletteOptions from "../colors";
 import { createCSSVarNames, createCSSVars } from "./utils";
 
 export const shadows = {
-  shadow1: `0px 4px 8px ${paletteOptions.token.core.shadow_01}`,
-  shadow2: `0px 3px 12px ${paletteOptions.token.core.shadow_02}`,
-  shadow3: `0px 12px 24px ${paletteOptions.token.core.shadow_03}`,
-  shadow4: `0px 12px 44px ${paletteOptions.token.core.shadow_04}`,
+  shadow1: `0px 4px 8px ${paletteOptions.lunit_token.core.shadow_01}`,
+  shadow2: `0px 3px 12px ${paletteOptions.lunit_token.core.shadow_02}`,
+  shadow3: `0px 12px 24px ${paletteOptions.lunit_token.core.shadow_03}`,
+  shadow4: `0px 12px 44px ${paletteOptions.lunit_token.core.shadow_04}`,
 };
 
 const shadowVars = createCSSVarNames(shadows);

--- a/packages/design-system/src/foundation/colors/index.ts
+++ b/packages/design-system/src/foundation/colors/index.ts
@@ -11,7 +11,7 @@ export type GreyColor = Record<keyof typeof base.grey, PaletteColor>;
 
 declare module "@mui/material/styles/createPalette" {
   interface PaletteOptions {
-    lunit?: {
+    lunit_global?: {
       grey: GreyColor;
       blue: BaseColor;
       green: BaseColor;
@@ -22,11 +22,11 @@ declare module "@mui/material/styles/createPalette" {
       red: BaseColor;
       yellow: BaseColor;
     };
-    token?: ColorToken;
+    lunit_token?: ColorToken;
   }
 
   interface Palette {
-    lunit: {
+    lunit_global: {
       grey: GreyColor;
       blue: BaseColor;
       green: BaseColor;
@@ -37,7 +37,7 @@ declare module "@mui/material/styles/createPalette" {
       red: BaseColor;
       yellow: BaseColor;
     };
-    token: ColorToken;
+    lunit_token: ColorToken;
   }
 }
 
@@ -123,6 +123,7 @@ export const createColorCssBaseline = () => {
 };
 
 // TODO: TextColors 삭제하고 관련된 설정 수정하기
+// TODO: opacity 글로벌 팔레트에 추가 여부 확인해서 작업하기
 const lunitColors: PaletteOptions["lunit"] = ((): PaletteOptions["lunit"] => {
   const ret: any = {};
   for (const colorKey in base) {
@@ -167,8 +168,8 @@ const paletteOptions = {
     main: base.green[40], // core.text_success.dark1
   },
   grey: base.greyForMUI,
-  lunit: lunitColors,
-  token: {
+  lunit_global: lunitColors,
+  lunit_token: {
     core: {
       bg_01: "var(--bg_01)",
       bg_02: "var(--bg_02)",

--- a/packages/design-system/src/foundation/colors/index.ts
+++ b/packages/design-system/src/foundation/colors/index.ts
@@ -124,29 +124,31 @@ export const createColorCssBaseline = () => {
 
 // TODO: TextColors 삭제하고 관련된 설정 수정하기
 // TODO: opacity 글로벌 팔레트에 추가 여부 확인해서 작업하기
-const lunitColors: PaletteOptions["lunit"] = ((): PaletteOptions["lunit"] => {
-  const ret: any = {};
-  for (const colorKey in base) {
-    if (base[`${colorKey}Text` as ColorKey]) {
-      const baseColors = base[colorKey as ColorKey];
-      const textColors = base[`${colorKey}Text` as ColorKey];
-      ret[colorKey] = {};
-      for (const key in baseColors) {
-        if (baseColors.hasOwnProperty(key)) {
-          const color = baseColors[Number(key) as keyof typeof baseColors];
-          const textColor = textColors[Number(key) as keyof typeof textColors];
-          ret[colorKey][Number(key)] = {
-            light: color,
-            main: color,
-            dark: color,
-            contrastText: textColor,
-          };
+const lunitColors: PaletteOptions["lunit_global"] =
+  ((): PaletteOptions["lunit_global"] => {
+    const ret: any = {};
+    for (const colorKey in base) {
+      if (base[`${colorKey}Text` as ColorKey]) {
+        const baseColors = base[colorKey as ColorKey];
+        const textColors = base[`${colorKey}Text` as ColorKey];
+        ret[colorKey] = {};
+        for (const key in baseColors) {
+          if (baseColors.hasOwnProperty(key)) {
+            const color = baseColors[Number(key) as keyof typeof baseColors];
+            const textColor =
+              textColors[Number(key) as keyof typeof textColors];
+            ret[colorKey][Number(key)] = {
+              light: color,
+              main: color,
+              dark: color,
+              contrastText: textColor,
+            };
+          }
         }
       }
     }
-  }
-  return ret;
-})();
+    return ret;
+  })();
 
 const paletteOptions = {
   primary: {

--- a/packages/design-system/src/stories/components/Alert/Alert.stories.tsx
+++ b/packages/design-system/src/stories/components/Alert/Alert.stories.tsx
@@ -62,7 +62,7 @@ const AlertChildrenContentLong = () => {
     <Typography variant="body2_14_regular">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut{" "}
-      <u style={{ color: theme.palette.token.core.link_primary }}>
+      <u style={{ color: theme.palette.lunit_token.core.link_primary }}>
         labore et dolore
       </u>{" "}
       magna aliqua. A diam sollicitudin tempor id eu nisl nunc mi. Auctor augue

--- a/packages/design-system/src/stories/foundation/Typography/TypographyGroup.tsx
+++ b/packages/design-system/src/stories/foundation/Typography/TypographyGroup.tsx
@@ -18,7 +18,7 @@ export const TypographyItem = styled(Box)({
 
 export const TypographyTitle = styled(Typography)(({ theme }) => ({
   width: 200,
-  color: theme.palette.token.core.text_light,
+  color: theme.palette.lunit_token.core.text_light,
 }));
 
 export const TypographyDummy = styled(Typography)({

--- a/packages/design-system/src/stories/foundation/colors/Colors.stories.tsx
+++ b/packages/design-system/src/stories/foundation/colors/Colors.stories.tsx
@@ -18,7 +18,7 @@ const BaseColors = () => {
   return (
     <Container>
       {map(
-        theme.palette.lunit,
+        theme.palette.lunit_global,
         (colors: BaseColor | GreyColor, paletteKey: string) => (
           <div key={paletteKey}>
             <Typography
@@ -34,8 +34,8 @@ const BaseColors = () => {
               {map(colors, (_: string, colorKey: string) => (
                 <ColorContainer key={colorKey}>
                   <Color
-                    color={`lunit.${paletteKey}.${colorKey}.contrastText`}
-                    bgcolor={`lunit.${paletteKey}.${colorKey}.main`}
+                    color={`lunit_global.${paletteKey}.${colorKey}.contrastText`}
+                    bgcolor={`lunit_global.${paletteKey}.${colorKey}.main`}
                   >
                     <Typography variant="h4">T</Typography>
                   </Color>

--- a/packages/design-system/src/stories/foundation/colors/Token.inComponent.stories.tsx
+++ b/packages/design-system/src/stories/foundation/colors/Token.inComponent.stories.tsx
@@ -153,13 +153,13 @@ const BaseBox = ({ theme, children }: BaseBoxProps) => {
       className={theme === "light" ? "light1" : "dark1"}
       width={500}
       height={200}
-      bgcolor={theme === "light" ? `lunit.grey.0.main` : `lunit.grey.80.main`}
+      bgcolor={(sxTheme) => sxTheme.palette.lunit_token.core.bg_01}
       border="1px solid"
       p={2}
     >
       <Typography
         variant="body1_16_semibold"
-        color={(theme) => theme.palette.lunit_token.core.text_normal}
+        color={(sxTheme) => sxTheme.palette.lunit_token.core.text_normal}
       >
         {theme === "light" ? "= light1 =" : "= dark1 ="}
       </Typography>

--- a/packages/design-system/src/stories/foundation/colors/Token.inComponent.stories.tsx
+++ b/packages/design-system/src/stories/foundation/colors/Token.inComponent.stories.tsx
@@ -5,13 +5,13 @@ import { Box, styled, TextField, Typography, useTheme } from "@mui/material";
 export const InComponentWithStyled = () => {
   const StyledTextField = styled(TextField)(({ theme }) => ({
     "& .MuiInputBase-root": {
-      backgroundColor: theme.palette.token.component.textfield_bg,
-      color: theme.palette.token.core.text_normal,
+      backgroundColor: theme.palette.lunit_token.component.textfield_bg,
+      color: theme.palette.lunit_token.core.text_normal,
       "& .MuiInputBase-input": {
         padding: "8px 16px",
       },
       "&.Mui-focused fieldset": {
-        borderColor: theme.palette.token.core.focused,
+        borderColor: theme.palette.lunit_token.core.focused,
       },
     },
   }));
@@ -49,13 +49,13 @@ export const InComponentWithSx = () => {
           sx={{
             "& .MuiInputBase-root": {
               backgroundColor: (theme) =>
-                theme.palette.token.component.textfield_bg,
-              color: (theme) => theme.palette.token.core.text_normal,
+                theme.palette.lunit_token.component.textfield_bg,
+              color: (theme) => theme.palette.lunit_token.core.text_normal,
               "& .MuiInputBase-input": {
                 padding: "8px 16px",
               },
               "&.Mui-focused fieldset": {
-                borderColor: (theme) => theme.palette.token.core.focused,
+                borderColor: (theme) => theme.palette.lunit_token.core.focused,
               },
             },
           }}
@@ -65,10 +65,11 @@ export const InComponentWithSx = () => {
           <Box
             sx={{
               backgroundColor: (theme) =>
-                theme.palette.token.component.alert_info_bg,
-              color: (theme) => theme.palette.token.component.alert_info_border,
+                theme.palette.lunit_token.component.alert_info_bg,
+              color: (theme) =>
+                theme.palette.lunit_token.component.alert_info_border,
               boxShadow: (theme) =>
-                `20px -10px 5px ${theme.palette.token.core.shadow_01}`,
+                `20px -10px 5px ${theme.palette.lunit_token.core.shadow_01}`,
               width: 300,
               height: 80,
             }}
@@ -83,13 +84,13 @@ export const InComponentWithSx = () => {
           sx={{
             "& .MuiInputBase-root": {
               backgroundColor: (theme) =>
-                theme.palette.token.component.textfield_bg,
-              color: (theme) => theme.palette.token.core.text_normal,
+                theme.palette.lunit_token.component.textfield_bg,
+              color: (theme) => theme.palette.lunit_token.core.text_normal,
               "& .MuiInputBase-input": {
                 padding: "8px 16px",
               },
               "&.Mui-focused fieldset": {
-                borderColor: (theme) => theme.palette.token.core.focused,
+                borderColor: (theme) => theme.palette.lunit_token.core.focused,
               },
             },
           }}
@@ -99,10 +100,11 @@ export const InComponentWithSx = () => {
           <Box
             sx={{
               backgroundColor: (theme) =>
-                theme.palette.token.component.alert_info_bg,
-              color: (theme) => theme.palette.token.component.alert_info_border,
+                theme.palette.lunit_token.component.alert_info_bg,
+              color: (theme) =>
+                theme.palette.lunit_token.component.alert_info_border,
               boxShadow: (theme) =>
-                `20px -10px 5px ${theme.palette.token.core.shadow_01}`,
+                `20px -10px 5px ${theme.palette.lunit_token.core.shadow_01}`,
               width: 300,
               height: 80,
             }}
@@ -124,7 +126,7 @@ export const InComponentWithInlineStyle = () => {
         <TextField
           placeholder="Inline Styled Text Field"
           style={{
-            backgroundColor: theme.palette.token.component.textfield_bg,
+            backgroundColor: theme.palette.lunit_token.component.textfield_bg,
           }}
         />
       </BaseBox>
@@ -132,7 +134,7 @@ export const InComponentWithInlineStyle = () => {
         <TextField
           placeholder="Inline Styled Text Field"
           style={{
-            backgroundColor: theme.palette.token.component.textfield_bg,
+            backgroundColor: theme.palette.lunit_token.component.textfield_bg,
           }}
         />
       </BaseBox>
@@ -157,7 +159,7 @@ const BaseBox = ({ theme, children }: BaseBoxProps) => {
     >
       <Typography
         variant="body1_16_semibold"
-        color={(theme) => theme.palette.token.core.text_normal}
+        color={(theme) => theme.palette.lunit_token.core.text_normal}
       >
         {theme === "light" ? "= light1 =" : "= dark1 ="}
       </Typography>

--- a/packages/design-system/src/stories/foundation/colors/TokenPaletteTable.tsx
+++ b/packages/design-system/src/stories/foundation/colors/TokenPaletteTable.tsx
@@ -25,7 +25,9 @@ const TokenPaletteTable = ({ kind }: TokenPaletteTableProps) => {
   const theme = useTheme();
 
   const colorTokenMap = Object.entries(
-    kind === "core" ? theme.palette.token.core : theme.palette.token.component
+    kind === "core"
+      ? theme.palette.lunit_token.core
+      : theme.palette.lunit_token.component
   );
 
   const TokenPaletteCell = (props: {
@@ -43,8 +45,8 @@ const TokenPaletteTable = ({ kind }: TokenPaletteTableProps) => {
 
     const boxColorByToken =
       kind === "core"
-        ? theme.palette.token.core[paletteKey as keyof ColorToken["core"]]
-        : theme.palette.token.component[
+        ? theme.palette.lunit_token.core[paletteKey as keyof ColorToken["core"]]
+        : theme.palette.lunit_token.component[
             paletteKey as keyof ColorToken["component"]
           ];
 
@@ -57,7 +59,7 @@ const TokenPaletteTable = ({ kind }: TokenPaletteTableProps) => {
       <TableCell
         className={surface}
         sx={{
-          background: theme.palette.token.core.bg_01,
+          background: theme.palette.lunit_token.core.bg_01,
           padding: 0,
         }}
       >

--- a/packages/design-system/src/stories/foundation/colors/styled.ts
+++ b/packages/design-system/src/stories/foundation/colors/styled.ts
@@ -33,7 +33,7 @@ export const Color = styled(Box)({
 });
 
 export const StyledTypography = styled(Typography)(({ theme }) => ({
-  color: theme.palette.token.core.text_normal,
+  color: theme.palette.lunit_token.core.text_normal,
   marginLeft: 8,
   fontSize: "12px",
 }));


### PR DESCRIPTION
[DS-76]

## Description

- MUI theme 내 lunit color token 과 lunit global color 의 구조가 mui 기본 palette 와 헷갈리는 이슈
- Lunit 에서 사용하는 컬러의 hierarchy 와 이름을 다음과 같이 수정하여 이용자들이 color token 사용 시 혼동을 막고자 함
    ```
    Global color : theme.palette.lunit =>  theme.palette.lunit_global
    Color Token  : theme.palette.token =>  theme.palette.lunit_token
    ```
- token 이름을 변경함에 따라 token 을 사용하고 있는 코드 수정 진행
<br />

#### ! 코드 찾아바꾸기로 전부 확인하여 바꾸었으니 컴포넌트 개발 담당자 분들은 이상없는지 리뷰 부탁드립니다. (commit message 참조)


[DS-76]: https://lunit.atlassian.net/browse/DS-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ