### PR TITLE
[DS-85] TextField Placeholder color token 변경

### DIFF
--- a/packages/design-system/src/components/TextField/TextField.style.ts
+++ b/packages/design-system/src/components/TextField/TextField.style.ts
@@ -97,9 +97,9 @@ const commonStyle = ({ lunit_token }: { lunit_token: ColorToken }) => ({
       padding: 0,
       textOverflow: "ellipsis",
       "&::placeholder": {
-        color: lunit_token.core.text_medium,
+        color: lunit_token.core.text_light,
         opacity: 1,
-        WebkitTextFillColor: lunit_token.core.text_medium,
+        WebkitTextFillColor: lunit_token.core.text_light,
       },
     },
     "& textarea": {


### PR DESCRIPTION
[DS-85]

## Description

- TextField color token 을 변경합니다.
<img width="1000" alt="스크린샷 2023-09-18 오후 3 58 25" src="https://github.com/lunit-io/design-system/assets/88369343/90d988fa-dba5-44b8-a398-c2ed5c4128b9">


[DS-85]: https://lunit.atlassian.net/browse/DS-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ