### PR TITLE
[DS-92] TextField width 100% 삭제

### DIFF
--- a/packages/design-system/src/components/TextField/TextField.style.ts
+++ b/packages/design-system/src/components/TextField/TextField.style.ts
@@ -71,12 +71,8 @@ const getTextFieldPaddingBySize = ({
 };
 
 const commonStyle = ({ lunit_token }: { lunit_token: ColorToken }) => ({
-  "&.MuiTextField-root": {
-    width: "100%",
-  },
   "& .MuiOutlinedInput-root": {
     borderRadius: "8px",
-    width: "100%",
 
     "& fieldset": {
       border: "none",


### PR DESCRIPTION
[DS-92](https://lunit.atlassian.net/browse/DS-92)

## Description

- TextField 에 적용된 width 100% 스타일을 삭제합니다.

[DS-92]: https://lunit.atlassian.net/browse/DS-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ