### PR TITLE
[DS-97] Purple color type 추가

### DIFF
--- a/packages/design-system/src/foundation/colors/index.ts
+++ b/packages/design-system/src/foundation/colors/index.ts
@@ -19,6 +19,7 @@ declare module "@mui/material/styles/createPalette" {
       lunit_teal: BaseColor;
       magenta: BaseColor;
       orange: BaseColor;
+      purple: BaseColor;
       red: BaseColor;
       yellow: BaseColor;
     };
@@ -34,6 +35,7 @@ declare module "@mui/material/styles/createPalette" {
       lunit_teal: BaseColor;
       magenta: BaseColor;
       orange: BaseColor;
+      purple: BaseColor;
       red: BaseColor;
       yellow: BaseColor;
     };


### PR DESCRIPTION
## Description
Purple 색상 정의는 이미 되어있었으나 `PaletteOption`, `Palette` 타입에 `purple` 항목이 정의되지 않아 해당 부분 수정

- Jira 이슈: https://lunit.atlassian.net/jira/software/projects/DS/boards/31?selectedIssue=DS-97