### PR TITLE
[DS-83] Chip component prop 적용 및 Button component prop 개선

### DIFF
--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -11,11 +11,11 @@ import type { ButtonProps } from "./Button.types";
 import type { ToggleButtonProps } from "../ToggleButton/ToggleButton.types";
 import type { Typography } from "@mui/material/styles/createTypography";
 
-type KindStyleParams = Pick<ButtonProps<"button">, "kind" | "color"> & {
+type KindStyleParams = Pick<ButtonProps, "kind" | "color"> & {
   lunit_token: ColorToken;
 };
 
-type CustomButtonProps = ButtonProps<"button"> & { hasIconOnly: boolean };
+type CustomButtonProps = ButtonProps & { hasIconOnly: boolean };
 
 type sizeStyleParams = Pick<
   CustomButtonProps,

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { CustomButton } from "./Button.styled";
 
-import type { ButtonProps } from "./Button.types";
+import type { ButtonType, ButtonProps } from "./Button.types";
 
-const Button = <C extends React.ElementType>(props: ButtonProps<C>) => {
+const Button: ButtonType = (props: ButtonProps) => {
   const {
     size = "small",
     color = "primary",

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -1,30 +1,43 @@
-import type { ButtonProps as MuiButtonProps } from "@mui/material";
+import type {
+  ButtonProps as MuiButtonProps,
+  ButtonTypeMap as MuiButtonTypeMap,
+} from "@mui/material";
+import type { OverridableComponent } from "@mui/material/OverridableComponent";
 
 /**
  * TODO: Omit 을 사용할 경우 component prop 타입 추론이 안되는 이슈 발생
  * https://github.com/lunit-io/design-system/pull/133#discussion_r1354277785
  * */
-type BaseButtonProps<C extends React.ElementType> = Omit<
-  MuiButtonProps<C, { component?: C }>,
-  "variant"
-> & { icon?: React.ReactNode; component?: C };
+interface BaseButtonProps extends Omit<MuiButtonProps, "variant"> {
+  icon?: React.ReactNode;
+}
 
-type ContainedButtonProps<C extends React.ElementType> = BaseButtonProps<C> & {
+interface ContainedButtonProps extends BaseButtonProps {
   kind?: "contained";
   color?: "primary" | "secondary" | "error";
-};
+}
 
-type GhostButtonProps<C extends React.ElementType> = BaseButtonProps<C> & {
+interface GhostButtonProps extends BaseButtonProps {
   kind?: "ghost";
   color?: "primary" | "secondary" | "error";
-};
+}
 
-type OutlinedButtonProps<C extends React.ElementType> = BaseButtonProps<C> & {
+interface OutlinedButtonProps extends BaseButtonProps {
   kind?: "outlined";
   color?: "primary" | "secondary";
+}
+
+export type ButtonProps =
+  | ContainedButtonProps
+  | GhostButtonProps
+  | OutlinedButtonProps;
+
+export type ButtonTypeMap<
+  P = {},
+  D extends React.ElementType = MuiButtonTypeMap["defaultComponent"]
+> = {
+  props: P & ButtonProps;
+  defaultComponent: D;
 };
 
-export type ButtonProps<C extends React.ElementType> =
-  | ContainedButtonProps<C>
-  | GhostButtonProps<C>
-  | OutlinedButtonProps<C>;
+export type ButtonType = OverridableComponent<ButtonTypeMap>;

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -7,7 +7,7 @@ import type { ButtonProps as MuiButtonProps } from "@mui/material";
 type BaseButtonProps<C extends React.ElementType> = Omit<
   MuiButtonProps<C, { component?: C }>,
   "variant"
-> & { icon?: React.ReactNode };
+> & { icon?: React.ReactNode; component?: C };
 
 type ContainedButtonProps<C extends React.ElementType> = BaseButtonProps<C> & {
   kind?: "contained";

--- a/packages/design-system/src/components/Button/utils/getButtonPaddingBySizeAndKind.ts
+++ b/packages/design-system/src/components/Button/utils/getButtonPaddingBySizeAndKind.ts
@@ -3,10 +3,7 @@ import { OUTLINED_BORDER_WIDTH } from "../const";
 import type { ButtonProps } from "../Button.types";
 import { ToggleButtonProps } from "@/components/ToggleButton/ToggleButton.types";
 
-type GetButtonPaddingBySizeAndKindParams = Pick<
-  ButtonProps<"button">,
-  "kind" | "size"
-> &
+type GetButtonPaddingBySizeAndKindParams = Pick<ButtonProps, "kind" | "size"> &
   Pick<ToggleButtonProps, "selected">;
 
 /**

--- a/packages/design-system/src/components/Button/utils/getIconButtonPaddingBySizeAndKind.ts
+++ b/packages/design-system/src/components/Button/utils/getIconButtonPaddingBySizeAndKind.ts
@@ -4,7 +4,7 @@ import type { ButtonProps } from "../Button.types";
 import { ToggleButtonProps } from "@/components/ToggleButton/ToggleButton.types";
 
 type GetIconButtonPaddingBySizeAndKindProps = Pick<
-  ButtonProps<"button">,
+  ButtonProps,
   "kind" | "size"
 > &
   Pick<ToggleButtonProps, "selected">;

--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -68,7 +68,7 @@ const getColorToken = (
 
 export const StyledOutlinedChip = styled(MuiChip, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<OutlinedChipProps>(({ theme, color }) => ({
+})<OutlinedChipProps<"div">>(({ theme, color }) => ({
   ...COMMON_STYLES,
   ...theme.typography.caption,
 
@@ -78,7 +78,7 @@ export const StyledOutlinedChip = styled(MuiChip, {
 
 export const StyledContainedChipBase = styled(MuiChip, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<BaseContainedChipProps>(() => ({ theme, color }) => ({
+})<BaseContainedChipProps<"div">>(() => ({ theme, color }) => ({
   ...COMMON_STYLES,
   ...theme.typography.caption,
 
@@ -112,7 +112,7 @@ export const StyledContainedChipBase = styled(MuiChip, {
 
 export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<EnableContainedChipProps>(() => ({ theme, color }) => ({
+})<EnableContainedChipProps<"div">>(() => ({ theme, color }) => ({
   /**
    * Setting the z-index of the chip to 0 and the z-index of the pseudo element to -1
    * allows the pseudo element(hover layer) to be rendered between the chip and the chip's children.
@@ -139,9 +139,9 @@ export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
   },
 }));
 
-export const StyledContainedChipDeletable = styled(
-  StyledContainedChipBase
-)<BaseContainedChipProps>(() => ({ theme }) => ({
+export const StyledContainedChipDeletable = styled(StyledContainedChipBase)<
+  BaseContainedChipProps<"div">
+>(() => ({ theme }) => ({
   "& .MuiChip-deleteIcon": {
     marginLeft: "4px",
     marginRight: "3px",

--- a/packages/design-system/src/components/Chip/Chip.styled.ts
+++ b/packages/design-system/src/components/Chip/Chip.styled.ts
@@ -68,7 +68,7 @@ const getColorToken = (
 
 export const StyledOutlinedChip = styled(MuiChip, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<OutlinedChipProps<"div">>(({ theme, color }) => ({
+})<OutlinedChipProps>(({ theme, color }) => ({
   ...COMMON_STYLES,
   ...theme.typography.caption,
 
@@ -78,7 +78,7 @@ export const StyledOutlinedChip = styled(MuiChip, {
 
 export const StyledContainedChipBase = styled(MuiChip, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<BaseContainedChipProps<"div">>(() => ({ theme, color }) => ({
+})<BaseContainedChipProps>(() => ({ theme, color }) => ({
   ...COMMON_STYLES,
   ...theme.typography.caption,
 
@@ -112,7 +112,7 @@ export const StyledContainedChipBase = styled(MuiChip, {
 
 export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
   shouldForwardProp: (prop) => !["color"].includes(prop.toString()),
-})<EnableContainedChipProps<"div">>(() => ({ theme, color }) => ({
+})<EnableContainedChipProps>(() => ({ theme, color }) => ({
   /**
    * Setting the z-index of the chip to 0 and the z-index of the pseudo element to -1
    * allows the pseudo element(hover layer) to be rendered between the chip and the chip's children.
@@ -139,9 +139,9 @@ export const StyledContainedChipEnable = styled(StyledContainedChipBase, {
   },
 }));
 
-export const StyledContainedChipDeletable = styled(StyledContainedChipBase)<
-  BaseContainedChipProps<"div">
->(() => ({ theme }) => ({
+export const StyledContainedChipDeletable = styled(
+  StyledContainedChipBase
+)<BaseContainedChipProps>(() => ({ theme }) => ({
   "& .MuiChip-deleteIcon": {
     marginLeft: "4px",
     marginRight: "3px",

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -17,7 +17,7 @@ import type {
   ChipThumbnail,
 } from "./Chip.types";
 
-const Chip = (props: ChipProps) => {
+const Chip = <C extends React.ElementType>(props: ChipProps<C>) => {
   const { kind, onDelete, onClick, ...restProps } = props;
   if (kind === "outlined") return <OutlinedChip {...props} />;
   else if (onClick) return <EnableContainedChip {...props} />;
@@ -26,7 +26,9 @@ const Chip = (props: ChipProps) => {
   return <ReadOnlyContainedChip {...restProps} />;
 };
 
-const OutlinedChip = (props: OutlinedChipProps) => {
+const OutlinedChip = <C extends React.ElementType>(
+  props: OutlinedChipProps<C>
+) => {
   const { color = "primary", ...restProps } = props;
 
   return (
@@ -61,7 +63,9 @@ const getLabelMargin = (
   };
 };
 
-const ReadOnlyContainedChip = (props: ReadOnlyContainedChipProps) => {
+const ReadOnlyContainedChip = <C extends React.ElementType>(
+  props: ReadOnlyContainedChipProps<C>
+) => {
   const { color = "primary", thumbnail, sx, ...restProps } = props;
 
   return (
@@ -81,8 +85,17 @@ const ReadOnlyContainedChip = (props: ReadOnlyContainedChipProps) => {
   );
 };
 
-const EnableContainedChip = (props: EnableContainedChipProps) => {
-  const { color = "primary", thumbnail, onClick, sx, ...restProps } = props;
+const EnableContainedChip = <C extends React.ElementType>(
+  props: EnableContainedChipProps<C>
+) => {
+  const {
+    color = "primary",
+    thumbnail,
+    onDelete,
+    onClick,
+    sx,
+    ...restProps
+  } = props;
 
   return (
     <StyledContainedChipEnable
@@ -108,7 +121,9 @@ const DeleteIconWithHoverLayer = ({ onClick }: { onClick: () => void }) => {
     </>
   );
 };
-const DeletableContainedChip = (props: DeletableContainedChipProps) => {
+const DeletableContainedChip = <C extends React.ElementType>(
+  props: DeletableContainedChipProps<C>
+) => {
   const { color = "primary", thumbnail, onDelete, sx, ...restProps } = props;
 
   return (

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -14,10 +14,11 @@ import type {
   EnableContainedChipProps,
   DeletableContainedChipProps,
   ChipProps,
+  ChipType,
   ChipThumbnail,
 } from "./Chip.types";
 
-const Chip = <C extends React.ElementType>(props: ChipProps<C>) => {
+const Chip: ChipType = (props: ChipProps) => {
   const { kind, onDelete, onClick, ...restProps } = props;
   if (kind === "outlined") return <OutlinedChip {...props} />;
   else if (onClick) return <EnableContainedChip {...props} />;
@@ -26,9 +27,7 @@ const Chip = <C extends React.ElementType>(props: ChipProps<C>) => {
   return <ReadOnlyContainedChip {...restProps} />;
 };
 
-const OutlinedChip = <C extends React.ElementType>(
-  props: OutlinedChipProps<C>
-) => {
+const OutlinedChip = (props: OutlinedChipProps) => {
   const { color = "primary", ...restProps } = props;
 
   return (
@@ -63,9 +62,7 @@ const getLabelMargin = (
   };
 };
 
-const ReadOnlyContainedChip = <C extends React.ElementType>(
-  props: ReadOnlyContainedChipProps<C>
-) => {
+const ReadOnlyContainedChip = (props: ReadOnlyContainedChipProps) => {
   const { color = "primary", thumbnail, sx, ...restProps } = props;
 
   return (
@@ -85,9 +82,7 @@ const ReadOnlyContainedChip = <C extends React.ElementType>(
   );
 };
 
-const EnableContainedChip = <C extends React.ElementType>(
-  props: EnableContainedChipProps<C>
-) => {
+const EnableContainedChip = (props: EnableContainedChipProps) => {
   const {
     color = "primary",
     thumbnail,
@@ -121,9 +116,7 @@ const DeleteIconWithHoverLayer = ({ onClick }: { onClick: () => void }) => {
     </>
   );
 };
-const DeletableContainedChip = <C extends React.ElementType>(
-  props: DeletableContainedChipProps<C>
-) => {
+const DeletableContainedChip = (props: DeletableContainedChipProps) => {
   const { color = "primary", thumbnail, onDelete, sx, ...restProps } = props;
 
   return (

--- a/packages/design-system/src/components/Chip/Chip.types.ts
+++ b/packages/design-system/src/components/Chip/Chip.types.ts
@@ -9,48 +9,55 @@ export type ChipThumbnail = string | JSX.Element;
 /**
  * Mui Chip's variant is 'kind' in our design system
  */
-export interface BaseChipProps
+export interface BaseChipProps<C extends React.ElementType>
   extends Pick<
-    MuiChipProps,
-    "label" | "sx" | "style" | "classes" | "onDelete"
+    MuiChipProps<C, { component?: C }>,
+    "label" | "sx" | "style" | "classes" | "component"
   > {
   kind?: "outlined" | "contained";
   color?: ChipColor;
 }
 
-export interface OutlinedChipProps extends BaseChipProps {
+export interface OutlinedChipProps<C extends React.ElementType>
+  extends BaseChipProps<C> {
   kind?: "outlined";
   onClick?: never;
   onDelete?: never;
 }
 
-export interface BaseContainedChipProps
-  extends BaseChipProps,
-    Omit<
-      MuiChipProps,
-      "color" | "size" | "variant" | "avatar" | "deleteIcon" | "icon"
-    > {
+export interface BaseContainedChipProps<C extends React.ElementType>
+  extends Omit<
+    BaseChipProps<C>,
+    "size" | "variant" | "avatar" | "deleteIcon" | "icon"
+  > {
   kind?: "contained";
   thumbnail?: ChipThumbnail;
   onClick?: () => void;
 }
 
-export interface ReadOnlyContainedChipProps extends BaseContainedChipProps {
+export interface ReadOnlyContainedChipProps<C extends React.ElementType>
+  extends BaseContainedChipProps<C> {
   onClick?: never;
   onDelete?: never;
 }
-export interface EnableContainedChipProps extends BaseContainedChipProps {
+
+export interface EnableContainedChipProps<C extends React.ElementType>
+  extends BaseContainedChipProps<C> {
   onClick: () => void;
   onDelete?: never;
 }
-export interface DeletableContainedChipProps extends BaseContainedChipProps {
+
+export interface DeletableContainedChipProps<C extends React.ElementType>
+  extends BaseContainedChipProps<C> {
   onClick?: never;
   onDelete: () => void;
 }
 
-export type ContainedChipProps =
-  | EnableContainedChipProps
-  | ReadOnlyContainedChipProps
-  | DeletableContainedChipProps;
+export type ContainedChipProps<C extends React.ElementType> =
+  | EnableContainedChipProps<C>
+  | ReadOnlyContainedChipProps<C>
+  | DeletableContainedChipProps<C>;
 
-export type ChipProps = OutlinedChipProps | ContainedChipProps;
+export type ChipProps<C extends React.ElementType> =
+  | OutlinedChipProps<C>
+  | ContainedChipProps<C>;

--- a/packages/design-system/src/components/Chip/Chip.types.ts
+++ b/packages/design-system/src/components/Chip/Chip.types.ts
@@ -1,6 +1,10 @@
 import { CHIP_COLORS } from "./consts";
 
-import type { ChipProps as MuiChipProps } from "@mui/material";
+import type {
+  ChipProps as MuiChipProps,
+  ChipTypeMap as MuiChipTypeMap,
+} from "@mui/material";
+import type { OverridableComponent } from "@mui/material/OverridableComponent";
 
 type ColorKeys = keyof typeof CHIP_COLORS;
 export type ChipColor = (typeof CHIP_COLORS)[ColorKeys];
@@ -9,55 +13,58 @@ export type ChipThumbnail = string | JSX.Element;
 /**
  * Mui Chip's variant is 'kind' in our design system
  */
-export interface BaseChipProps<C extends React.ElementType>
+export interface BaseChipProps
   extends Pick<
-    MuiChipProps<C, { component?: C }>,
-    "label" | "sx" | "style" | "classes" | "component"
+    MuiChipProps,
+    "label" | "sx" | "style" | "classes" | "onDelete"
   > {
   kind?: "outlined" | "contained";
   color?: ChipColor;
 }
 
-export interface OutlinedChipProps<C extends React.ElementType>
-  extends BaseChipProps<C> {
+export interface OutlinedChipProps extends BaseChipProps {
   kind?: "outlined";
   onClick?: never;
   onDelete?: never;
 }
 
-export interface BaseContainedChipProps<C extends React.ElementType>
-  extends Omit<
-    BaseChipProps<C>,
-    "size" | "variant" | "avatar" | "deleteIcon" | "icon"
-  > {
+export interface BaseContainedChipProps
+  extends BaseChipProps,
+    Omit<
+      MuiChipProps,
+      "color" | "size" | "variant" | "avatar" | "deleteIcon" | "icon"
+    > {
   kind?: "contained";
   thumbnail?: ChipThumbnail;
   onClick?: () => void;
 }
 
-export interface ReadOnlyContainedChipProps<C extends React.ElementType>
-  extends BaseContainedChipProps<C> {
+export interface ReadOnlyContainedChipProps extends BaseContainedChipProps {
   onClick?: never;
   onDelete?: never;
 }
-
-export interface EnableContainedChipProps<C extends React.ElementType>
-  extends BaseContainedChipProps<C> {
+export interface EnableContainedChipProps extends BaseContainedChipProps {
   onClick: () => void;
   onDelete?: never;
 }
-
-export interface DeletableContainedChipProps<C extends React.ElementType>
-  extends BaseContainedChipProps<C> {
+export interface DeletableContainedChipProps extends BaseContainedChipProps {
   onClick?: never;
   onDelete: () => void;
 }
 
-export type ContainedChipProps<C extends React.ElementType> =
-  | EnableContainedChipProps<C>
-  | ReadOnlyContainedChipProps<C>
-  | DeletableContainedChipProps<C>;
+export type ContainedChipProps =
+  | EnableContainedChipProps
+  | ReadOnlyContainedChipProps
+  | DeletableContainedChipProps;
 
-export type ChipProps<C extends React.ElementType> =
-  | OutlinedChipProps<C>
-  | ContainedChipProps<C>;
+export type ChipProps = OutlinedChipProps | ContainedChipProps;
+
+export type ChipTypeMap<
+  P = {},
+  D extends React.ElementType = MuiChipTypeMap["defaultComponent"]
+> = {
+  props: P & ChipProps;
+  defaultComponent: D;
+};
+
+export type ChipType = OverridableComponent<ChipTypeMap>;


### PR DESCRIPTION
[DS-83]

## Description

Chip 에 `component` prop 을 추가합니다.

[기존 Generic 방식](https://mui.com/material-ui/guides/composition/#with-typescript)은 타입 추론 이슈가 있어 `OverridableComponent` 을 사용한 방법을 적용합니다.

- [OverridableComponent 를 활용한 component 적용 방식](https://github.com/mui/material-ui/issues/35026#issuecomment-1322630219)
- [OverridableComponent 관련 예제](https://codesandbox.io/s/confident-sun-652mrk?file=/src/App.tsx)

[DS-83]: https://lunit.atlassian.net/browse/DS-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ