### PR TITLE
[DS-104] kind props의 alias로 variant 사용

### DIFF
--- a/apps/nextjs-test-system/components/SidePanel.tsx
+++ b/apps/nextjs-test-system/components/SidePanel.tsx
@@ -77,7 +77,6 @@ function SidePanel() {
         <Legend>Name*</Legend>
         <TextField
           size="medium"
-          variant="outlined"
           placeholder="Youjinnnnnn*"
           sx={{
             width: "100%",
@@ -92,7 +91,6 @@ function SidePanel() {
         <Legend>Study Description</Legend>
         <TextField
           size="medium"
-          variant="outlined"
           multiline
           sx={{
             width: "100%",

--- a/apps/nextjs-test-system/components/SidePanel.tsx
+++ b/apps/nextjs-test-system/components/SidePanel.tsx
@@ -76,6 +76,7 @@ function SidePanel() {
       <Fieldset>
         <Legend>Name*</Legend>
         <TextField
+          variant="outlined"
           size="medium"
           placeholder="Youjinnnnnn*"
           sx={{
@@ -90,6 +91,7 @@ function SidePanel() {
       <Fieldset>
         <Legend>Study Description</Legend>
         <TextField
+          variant="filled"
           size="medium"
           multiline
           sx={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
-        "@lunit/design-system": "1.0.0-b.1",
+        "@lunit/design-system": "1.0.0-b.4",
         "@lunit/design-system-logo": "*",
         "@mui/material": "^5.13.1",
         "@types/node": "20.2.3",
@@ -21264,7 +21264,7 @@
     },
     "packages/design-system": {
       "name": "@lunit/design-system",
-      "version": "1.0.0-b.1",
+      "version": "1.0.0-b.4",
       "license": "MIT",
       "dependencies": {
         "@lunit/design-system-icons": "*"
@@ -21315,7 +21315,7 @@
     },
     "packages/design-system-icons": {
       "name": "@lunit/design-system-icons",
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "UNLICENSED",
       "devDependencies": {
         "@babel/core": "^7.17.5",

--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -10,7 +10,6 @@ import getHoverStyle from "./utils/getHoverStyle";
 import type { ButtonProps } from "./Button.types";
 import type { ToggleButtonProps } from "../ToggleButton/ToggleButton.types";
 import type { Typography } from "@mui/material/styles/createTypography";
-import type { StyledComponent } from "@emotion/styled";
 
 type KindStyleParams = Pick<ButtonProps, "kind" | "color"> & {
   lunit_token: ColorToken;
@@ -244,4 +243,4 @@ export const CustomButton = styled(MuiButton, {
     ...sizeStyle({ size, kind, hasIconOnly, typography }),
     ...kindStyle({ kind, color, lunit_token }),
   })
-) as StyledComponent<CustomButtonProps>;
+);

--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -10,6 +10,7 @@ import getHoverStyle from "./utils/getHoverStyle";
 import type { ButtonProps } from "./Button.types";
 import type { ToggleButtonProps } from "../ToggleButton/ToggleButton.types";
 import type { Typography } from "@mui/material/styles/createTypography";
+import type { StyledComponent } from "@emotion/styled";
 
 type KindStyleParams = Pick<ButtonProps, "kind" | "color"> & {
   lunit_token: ColorToken;
@@ -225,7 +226,7 @@ export const iconStyle = ({
 
 export const CustomButton = styled(MuiButton, {
   shouldForwardProp: (prop: string) => {
-    return !["kind", "hasIconOnly"].includes(prop);
+    return !["kind", "hasIconOnly", "variant"].includes(prop);
   },
 })<CustomButtonProps>(
   ({
@@ -243,4 +244,4 @@ export const CustomButton = styled(MuiButton, {
     ...sizeStyle({ size, kind, hasIconOnly, typography }),
     ...kindStyle({ kind, color, lunit_token }),
   })
-);
+) as StyledComponent<CustomButtonProps>;

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -50,11 +50,13 @@ const GhostButton = forwardRef<
     children,
     startIcon,
     hasIconOnly,
+    variant,
+    ...restProps
   } = props;
 
   return (
     <CustomButton
-      {...props}
+      {...restProps}
       ref={ref}
       className={`ghost ${className ? className : ""}`}
       kind="ghost"
@@ -79,11 +81,13 @@ const OutlinedButton = forwardRef<
     children,
     startIcon,
     hasIconOnly,
+    variant,
+    ...restProps
   } = props;
 
   return (
     <CustomButton
-      {...props}
+      {...restProps}
       ref={ref}
       className={`outlined ${className ? className : ""}`}
       kind="outlined"
@@ -108,11 +112,13 @@ const ContainedButton = forwardRef<
     children,
     startIcon,
     hasIconOnly,
+    variant,
+    ...restProps
   } = props;
 
   return (
     <CustomButton
-      {...props}
+      {...restProps}
       ref={ref}
       className={`${props.kind ?? "contained"} ${className ? className : ""}`}
       kind={props.kind ?? "contained"}

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -2,59 +2,128 @@ import React, { forwardRef } from "react";
 
 import { CustomButton } from "./Button.styled";
 
-import type { ButtonType, ButtonProps } from "./Button.types";
+import type {
+  ButtonType,
+  ButtonProps,
+  GhostButtonProps,
+  OutlinedButtonProps,
+  ContainedButtonProps,
+} from "./Button.types";
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  const {
-    size = "small",
-    color = "primary",
-    icon,
-    className,
-    children,
-    startIcon,
-    ...buttonProps
-  } = props;
+  const { kind, variant, icon, children, startIcon } = props;
   const hasIconOnly = Boolean((startIcon || icon) && !children);
 
+  if (kind === "outlined" || variant === "outlined") {
+    return <OutlinedButton {...props} ref={ref} hasIconOnly={hasIconOnly} />;
+  }
+
+  if (kind === "ghost" || variant === "text" || variant === "ghost") {
+    return <GhostButton {...props} ref={ref} hasIconOnly={hasIconOnly} />;
+  }
+
   return (
-    <>
-      {/** props.kind 사용 이유: props.color 내 타입 좁히기 활용을 위해 사용 */}
-      {props.kind === "outlined" ? (
-        <CustomButton
-          {...buttonProps}
-          ref={ref}
-          className={`outlined ${className ? className : ""}`}
-          kind="outlined"
-          color={props.color ?? "primary"}
-          size={size}
-          startIcon={startIcon || icon}
-          hasIconOnly={hasIconOnly}
-        >
-          {!hasIconOnly && <>{children}</>}
-        </CustomButton>
-      ) : (
-        <CustomButton
-          {...buttonProps}
-          ref={ref}
-          className={`${props.kind ?? "contained"} ${
-            className ? className : ""
-          }`}
-          kind={props.kind ?? "contained"}
-          color={props.color ?? "primary"}
-          size={size}
-          startIcon={startIcon || icon}
-          hasIconOnly={hasIconOnly}
-        >
-          {!hasIconOnly && <>{children}</>}
-        </CustomButton>
-      )}
-    </>
+    <ContainedButton
+      {...props}
+      kind="contained"
+      variant="contained"
+      ref={ref}
+      hasIconOnly={hasIconOnly}
+    />
   );
+
   /**
    * There is an issue between React 18, Mui's OverridableComponent type and the
    * type coercion to temporarily fix it.
    * https://github.com/lunit-io/design-system/pull/143#issuecomment-1831127232
    */
 }) as ButtonType;
+
+const GhostButton = forwardRef<
+  HTMLButtonElement,
+  GhostButtonProps & { hasIconOnly: boolean }
+>((props, ref) => {
+  const {
+    size = "small",
+    icon,
+    className,
+    children,
+    startIcon,
+    hasIconOnly,
+  } = props;
+
+  return (
+    <CustomButton
+      {...props}
+      ref={ref}
+      className={`ghost ${className ? className : ""}`}
+      kind="ghost"
+      color={props.color ?? "primary"}
+      size={size}
+      startIcon={startIcon || icon}
+      hasIconOnly={hasIconOnly}
+    >
+      {!hasIconOnly && <>{children}</>}
+    </CustomButton>
+  );
+});
+
+const OutlinedButton = forwardRef<
+  HTMLButtonElement,
+  OutlinedButtonProps & { hasIconOnly: boolean }
+>((props, ref) => {
+  const {
+    size = "small",
+    icon,
+    className,
+    children,
+    startIcon,
+    hasIconOnly,
+  } = props;
+
+  return (
+    <CustomButton
+      {...props}
+      ref={ref}
+      className={`outlined ${className ? className : ""}`}
+      kind="outlined"
+      color={props.color ?? "primary"}
+      size={size}
+      startIcon={startIcon || icon}
+      hasIconOnly={hasIconOnly}
+    >
+      {!hasIconOnly && <>{children}</>}
+    </CustomButton>
+  );
+});
+
+const ContainedButton = forwardRef<
+  HTMLButtonElement,
+  ContainedButtonProps & { hasIconOnly: boolean }
+>((props, ref) => {
+  const {
+    size = "small",
+    icon,
+    className,
+    children,
+    startIcon,
+    hasIconOnly,
+  } = props;
+
+  return (
+    <CustomButton
+      {...props}
+      ref={ref}
+      className={`${props.kind ?? "contained"} ${className ? className : ""}`}
+      kind={props.kind ?? "contained"}
+      color={props.color ?? "primary"}
+      size={size}
+      startIcon={startIcon || icon}
+      hasIconOnly={hasIconOnly}
+    >
+      {!hasIconOnly && <>{children}</>}
+    </CustomButton>
+  );
+});
 
 export default Button;

--- a/packages/design-system/src/components/Button/Button.types.ts
+++ b/packages/design-system/src/components/Button/Button.types.ts
@@ -8,22 +8,26 @@ import type { OverridableComponent } from "@mui/material/OverridableComponent";
  * TODO: Omit 을 사용할 경우 component prop 타입 추론이 안되는 이슈 발생
  * https://github.com/lunit-io/design-system/pull/133#discussion_r1354277785
  * */
-interface BaseButtonProps extends Omit<MuiButtonProps, "variant"> {
+export interface BaseButtonProps extends Omit<MuiButtonProps, "variant"> {
   icon?: React.ReactNode;
+  variant?: "contained" | "outlined" | "text" | "ghost";
 }
 
-interface ContainedButtonProps extends BaseButtonProps {
+export interface ContainedButtonProps extends BaseButtonProps {
   kind?: "contained";
+  variant?: "contained";
   color?: "primary" | "secondary" | "error";
 }
 
-interface GhostButtonProps extends BaseButtonProps {
+export interface GhostButtonProps extends BaseButtonProps {
   kind?: "ghost";
+  variant?: "text" | "ghost";
   color?: "primary" | "secondary" | "error";
 }
 
-interface OutlinedButtonProps extends BaseButtonProps {
+export interface OutlinedButtonProps extends BaseButtonProps {
   kind?: "outlined";
+  variant?: "outlined";
   color?: "primary" | "secondary";
 }
 

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -19,8 +19,11 @@ import type {
 } from "./Chip.types";
 
 const Chip: ChipType = (props: ChipProps) => {
-  const { kind, onDelete, onClick, ...restProps } = props;
-  if (kind === "outlined") return <OutlinedChip {...props} />;
+  const { kind, variant, onDelete, onClick, ...restProps } = props;
+
+  const isOutlined = kind === "outlined" || variant === "outlined";
+
+  if (isOutlined) return <OutlinedChip {...props} />;
   else if (onClick) return <EnableContainedChip {...props} />;
   else if (onDelete) return <DeletableContainedChip {...props} />;
 

--- a/packages/design-system/src/components/Chip/Chip.tsx
+++ b/packages/design-system/src/components/Chip/Chip.tsx
@@ -66,7 +66,7 @@ const getLabelMargin = (
 };
 
 const ReadOnlyContainedChip = (props: ReadOnlyContainedChipProps) => {
-  const { color = "primary", thumbnail, sx, ...restProps } = props;
+  const { color = "primary", thumbnail, sx, variant, ...restProps } = props;
 
   return (
     <StyledContainedChipBase
@@ -92,6 +92,7 @@ const EnableContainedChip = (props: EnableContainedChipProps) => {
     onDelete,
     onClick,
     sx,
+    variant,
     ...restProps
   } = props;
 
@@ -120,7 +121,14 @@ const DeleteIconWithHoverLayer = ({ onClick }: { onClick: () => void }) => {
   );
 };
 const DeletableContainedChip = (props: DeletableContainedChipProps) => {
-  const { color = "primary", thumbnail, onDelete, sx, ...restProps } = props;
+  const {
+    color = "primary",
+    thumbnail,
+    onDelete,
+    sx,
+    variant,
+    ...restProps
+  } = props;
 
   return (
     <StyledContainedChipDeletable

--- a/packages/design-system/src/components/Chip/Chip.types.ts
+++ b/packages/design-system/src/components/Chip/Chip.types.ts
@@ -6,7 +6,8 @@ import type {
 } from "@mui/material";
 import type { OverridableComponent } from "@mui/material/OverridableComponent";
 
-type ChipKind = "outlined" | "contained";
+type DesignSystemChipKind = "outlined" | "contained";
+type DesignSystemAndMuiContainedChipKind = "filled" | "contained";
 type ColorKeys = keyof typeof CHIP_COLORS;
 export type ChipColor = (typeof CHIP_COLORS)[ColorKeys];
 export type ChipThumbnail = string | JSX.Element;
@@ -17,10 +18,12 @@ export type ChipThumbnail = string | JSX.Element;
 export interface BaseChipProps
   extends Pick<
     MuiChipProps,
-    "label" | "sx" | "style" | "classes" | "onDelete" | "variant"
+    "label" | "sx" | "style" | "classes" | "onDelete"
   > {
   // either kind or variant
-  kind?: ChipKind;
+  kind?: DesignSystemChipKind;
+  variant?: "outlined" | DesignSystemAndMuiContainedChipKind;
+  // mui variant = outlined | "filled" | undefined
   color?: ChipColor;
 }
 
@@ -33,9 +36,12 @@ export interface OutlinedChipProps extends BaseChipProps {
 
 export interface BaseContainedChipProps
   extends BaseChipProps,
-    Omit<MuiChipProps, "color" | "size" | "avatar" | "deleteIcon" | "icon"> {
+    Omit<
+      MuiChipProps,
+      "color" | "size" | "avatar" | "deleteIcon" | "icon" | "variant"
+    > {
   kind?: "contained";
-  variant?: "filled";
+  variant?: DesignSystemAndMuiContainedChipKind;
   thumbnail?: ChipThumbnail;
   onClick?: () => void;
 }

--- a/packages/design-system/src/components/Chip/Chip.types.ts
+++ b/packages/design-system/src/components/Chip/Chip.types.ts
@@ -6,6 +6,7 @@ import type {
 } from "@mui/material";
 import type { OverridableComponent } from "@mui/material/OverridableComponent";
 
+type ChipKind = "outlined" | "contained";
 type ColorKeys = keyof typeof CHIP_COLORS;
 export type ChipColor = (typeof CHIP_COLORS)[ColorKeys];
 export type ChipThumbnail = string | JSX.Element;
@@ -16,25 +17,25 @@ export type ChipThumbnail = string | JSX.Element;
 export interface BaseChipProps
   extends Pick<
     MuiChipProps,
-    "label" | "sx" | "style" | "classes" | "onDelete"
+    "label" | "sx" | "style" | "classes" | "onDelete" | "variant"
   > {
-  kind?: "outlined" | "contained";
+  // either kind or variant
+  kind?: ChipKind;
   color?: ChipColor;
 }
 
 export interface OutlinedChipProps extends BaseChipProps {
   kind?: "outlined";
+  variant?: "outlined";
   onClick?: never;
   onDelete?: never;
 }
 
 export interface BaseContainedChipProps
   extends BaseChipProps,
-    Omit<
-      MuiChipProps,
-      "color" | "size" | "variant" | "avatar" | "deleteIcon" | "icon"
-    > {
+    Omit<MuiChipProps, "color" | "size" | "avatar" | "deleteIcon" | "icon"> {
   kind?: "contained";
+  variant?: "filled";
   thumbnail?: ChipThumbnail;
   onClick?: () => void;
 }

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -25,6 +25,7 @@ const SingleTextField = forwardRef<HTMLDivElement, SingleTextFieldProps>(
 
     return (
       <BaseTextField
+        variant="outlined"
         {...restProps}
         ref={ref}
         textFieldSize={size}
@@ -57,19 +58,19 @@ const SingleTextField = forwardRef<HTMLDivElement, SingleTextFieldProps>(
 const MultiTextField = forwardRef<HTMLDivElement, MultiTextFieldProps>(
   ({ size = "small", ...restProps }, ref) => {
     return (
-      <BaseTextField {...restProps} ref={ref} textFieldSize={size} multiline />
+      <BaseTextField
+        variant="outlined"
+        {...restProps}
+        ref={ref}
+        textFieldSize={size}
+        multiline
+      />
     );
   }
 );
 
 const TextField = forwardRef<HTMLDivElement, TextFieldProps>((props, ref) => {
-  const {
-    rows,
-    size,
-    multiline = false,
-    variant = "outlined",
-    ...restProps
-  } = props;
+  const { rows, size, multiline = false, ...restProps } = props;
 
   return multiline ? (
     <MultiTextField
@@ -77,11 +78,10 @@ const TextField = forwardRef<HTMLDivElement, TextFieldProps>((props, ref) => {
       ref={ref}
       maxRows={Infinity}
       size={size}
-      variant={variant}
       rows={rows}
     />
   ) : (
-    <SingleTextField {...restProps} ref={ref} size={size} variant={variant} />
+    <SingleTextField {...restProps} ref={ref} size={size} />
   );
 });
 

--- a/packages/design-system/src/components/TextField/TextField.tsx
+++ b/packages/design-system/src/components/TextField/TextField.tsx
@@ -70,7 +70,7 @@ const MultiTextField = forwardRef<HTMLDivElement, MultiTextFieldProps>(
 );
 
 const TextField = forwardRef<HTMLDivElement, TextFieldProps>((props, ref) => {
-  const { rows, size, multiline = false, ...restProps } = props;
+  const { rows, size, multiline = false, variant, ...restProps } = props;
 
   return multiline ? (
     <MultiTextField

--- a/packages/design-system/src/components/TextField/TextField.types.ts
+++ b/packages/design-system/src/components/TextField/TextField.types.ts
@@ -8,9 +8,9 @@ export interface BaseTextFieldProps
     "size" | "value" | "helperText" | "variant"
   > {
   /**
-   * The design system TextField variable is outlined fixed.
+   * The design system TextField has only on kind
    */
-  variant?: "outlined";
+  // kind?: "contained"
   value?: string;
   helperText?: string;
 

--- a/packages/design-system/src/components/TextField/TextField.types.ts
+++ b/packages/design-system/src/components/TextField/TextField.types.ts
@@ -1,5 +1,8 @@
 import type { SxProps } from "@mui/material";
-import type { OutlinedTextFieldProps } from "@mui/material/TextField";
+import type {
+  TextFieldProps as MuiTextFieldProps,
+  OutlinedTextFieldProps,
+} from "@mui/material/TextField";
 
 export type TextFieldSize = "small" | "medium" | "large";
 export interface BaseTextFieldProps
@@ -8,12 +11,16 @@ export interface BaseTextFieldProps
     "size" | "value" | "helperText" | "variant"
   > {
   /**
-   * The design system TextField has only on kind
+   * The design system TextField has only on kind, which is "contained"
+    Below are all return same kind "contained"
+    <TextField variant="outlined" />
+    <TextField variant="contained" />
+    <TextField variant="filled" />
+    <TextField variant="standard" />
    */
-  // kind?: "contained"
+  variant?: MuiTextFieldProps["variant"];
   value?: string;
   helperText?: string;
-
   /**
    * @default "small"
    */

--- a/packages/design-system/src/stories/components/Button/BasicButton.stories.tsx
+++ b/packages/design-system/src/stories/components/Button/BasicButton.stories.tsx
@@ -50,6 +50,16 @@ export default {
         defaultValue: { summary: "contained" },
       },
     },
+    variant: {
+      control: {
+        type: "radio",
+      },
+      options: ["contained", "outlined", "text", "ghost"],
+      description: "The variant is alias of kind.",
+      table: {
+        defaultValue: { summary: "contained" },
+      },
+    },
     color: {
       control: {
         type: "radio",
@@ -98,6 +108,7 @@ export default {
         "disabled",
         "size",
         "kind",
+        "variant",
         "color",
         "icon",
       ],

--- a/packages/design-system/src/stories/components/Button/IconButton.stories.tsx
+++ b/packages/design-system/src/stories/components/Button/IconButton.stories.tsx
@@ -36,6 +36,16 @@ export default {
         defaultValue: { summary: "contained" },
       },
     },
+    variant: {
+      control: {
+        type: "radio",
+      },
+      options: ["contained", "outlined", "text", "ghost"],
+      description: "The variant is alias of kind.",
+      table: {
+        defaultValue: { summary: "contained" },
+      },
+    },
     color: {
       control: {
         type: "radio",
@@ -85,6 +95,7 @@ export default {
         "disabled",
         "size",
         "kind",
+        "variant",
         "color",
       ],
     },

--- a/packages/design-system/src/stories/components/Button/Kind.stories.tsx
+++ b/packages/design-system/src/stories/components/Button/Kind.stories.tsx
@@ -64,10 +64,28 @@ export default {
         defaultValue: { summary: "contained" },
       },
     },
+    variant: {
+      control: {
+        type: "radio",
+      },
+      options: ["contained", "outlined", "text", "ghost"],
+      description: "The variant is alias of kind.",
+      table: {
+        defaultValue: { summary: "contained" },
+      },
+    },
   },
   parameters: {
     controls: {
-      include: ["onClick", "children", "color", "size", "disabled", "kind"],
+      include: [
+        "onClick",
+        "children",
+        "color",
+        "size",
+        "disabled",
+        "kind",
+        "variant",
+      ],
     },
     pseudo: {
       hover: [
@@ -92,6 +110,7 @@ export default {
 const ButtonTemplate: StoryFn<typeof Button> = ({
   kind,
   color,
+  variant,
   children,
   ...restProps
 }) => {
@@ -157,6 +176,7 @@ export const Kind = {
 };
 
 const ContainedButtonTemplate: StoryFn<typeof Button> = (args) => {
+  const { kind, variant, ...restProps } = args;
   return (
     <>
       <Table sx={{ width: 650 }}>
@@ -182,17 +202,17 @@ const ContainedButtonTemplate: StoryFn<typeof Button> = (args) => {
               Enable
             </TableCell>
             <TableCell>
-              <Button {...args} kind="contained">
+              <Button {...restProps} kind="contained">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="contained" color="secondary">
+              <Button {...restProps} kind="contained" color="secondary">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="contained" color="error">
+              <Button {...restProps} kind="contained" color="error">
                 {args.children}
               </Button>
             </TableCell>
@@ -204,17 +224,22 @@ const ContainedButtonTemplate: StoryFn<typeof Button> = (args) => {
               Hover
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover1" kind="contained">
+              <Button {...restProps} id="hover1" kind="contained">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover2" kind="contained" color="secondary">
+              <Button
+                {...restProps}
+                id="hover2"
+                kind="contained"
+                color="secondary"
+              >
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover3" kind="contained" color="error">
+              <Button {...restProps} id="hover3" kind="contained" color="error">
                 {args.children}
               </Button>
             </TableCell>
@@ -226,13 +251,17 @@ const ContainedButtonTemplate: StoryFn<typeof Button> = (args) => {
               Focus
             </TableCell>
             <TableCell>
-              <Button {...args} kind="contained" className="Mui-focusVisible">
+              <Button
+                {...restProps}
+                kind="contained"
+                className="Mui-focusVisible"
+              >
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
               <Button
-                {...args}
+                {...restProps}
                 kind="contained"
                 color="secondary"
                 className="Mui-focusVisible"
@@ -242,7 +271,7 @@ const ContainedButtonTemplate: StoryFn<typeof Button> = (args) => {
             </TableCell>
             <TableCell>
               <Button
-                {...args}
+                {...restProps}
                 kind="contained"
                 color="error"
                 className="Mui-focusVisible"
@@ -258,17 +287,22 @@ const ContainedButtonTemplate: StoryFn<typeof Button> = (args) => {
               Disabled
             </TableCell>
             <TableCell>
-              <Button {...args} kind="contained" disabled>
+              <Button {...restProps} kind="contained" disabled>
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="contained" color="secondary" disabled>
+              <Button
+                {...restProps}
+                kind="contained"
+                color="secondary"
+                disabled
+              >
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="contained" color="error" disabled>
+              <Button {...restProps} kind="contained" color="error" disabled>
                 {args.children}
               </Button>
             </TableCell>
@@ -300,6 +334,7 @@ export const KindContained = {
 };
 
 const GhostButtonTemplate: StoryFn<typeof Button> = (args) => {
+  const { kind, variant, ...restProps } = args;
   return (
     <>
       <Table sx={{ width: 650 }}>
@@ -325,17 +360,17 @@ const GhostButtonTemplate: StoryFn<typeof Button> = (args) => {
               Enable
             </TableCell>
             <TableCell>
-              <Button {...args} kind="ghost">
+              <Button {...restProps} kind="ghost">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="ghost" color="secondary">
+              <Button {...restProps} kind="ghost" color="secondary">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="ghost" color="error">
+              <Button {...restProps} kind="ghost" color="error">
                 {args.children}
               </Button>
             </TableCell>
@@ -347,17 +382,17 @@ const GhostButtonTemplate: StoryFn<typeof Button> = (args) => {
               Hover
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover4" kind="ghost">
+              <Button {...restProps} id="hover4" kind="ghost">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover5" kind="ghost" color="secondary">
+              <Button {...restProps} id="hover5" kind="ghost" color="secondary">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} id="hover6" kind="ghost" color="error">
+              <Button {...restProps} id="hover6" kind="ghost" color="error">
                 {args.children}
               </Button>
             </TableCell>
@@ -369,13 +404,13 @@ const GhostButtonTemplate: StoryFn<typeof Button> = (args) => {
               Focus
             </TableCell>
             <TableCell>
-              <Button {...args} kind="ghost" className="Mui-focusVisible">
+              <Button {...restProps} kind="ghost" className="Mui-focusVisible">
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
               <Button
-                {...args}
+                {...restProps}
                 kind="ghost"
                 color="secondary"
                 className="Mui-focusVisible"
@@ -385,7 +420,7 @@ const GhostButtonTemplate: StoryFn<typeof Button> = (args) => {
             </TableCell>
             <TableCell>
               <Button
-                {...args}
+                {...restProps}
                 kind="ghost"
                 color="error"
                 className="Mui-focusVisible"
@@ -401,17 +436,17 @@ const GhostButtonTemplate: StoryFn<typeof Button> = (args) => {
               Disabled
             </TableCell>
             <TableCell>
-              <Button {...args} kind="ghost" disabled>
+              <Button {...restProps} kind="ghost" disabled>
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="ghost" color="secondary" disabled>
+              <Button {...restProps} kind="ghost" color="secondary" disabled>
                 {args.children}
               </Button>
             </TableCell>
             <TableCell>
-              <Button {...args} kind="ghost" color="error" disabled>
+              <Button {...restProps} kind="ghost" color="error" disabled>
                 {args.children}
               </Button>
             </TableCell>
@@ -445,6 +480,8 @@ export const KindGhost = {
 };
 
 const OutlinedButtonTemplate: StoryFn<typeof Button> = ({
+  kind,
+  variant,
   color,
   ...restProps
 }) => {

--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -18,6 +18,13 @@ export default {
     kind: {
       description: `Default status of Contained or Outlined Chip is readOnly. You can pass onClick, onDelete or thumbnail to Contained Chip only.`,
     },
+    variant: {
+      description: `The variant is alias of kind. It is Filled or Outlined.`,
+      control: {
+        type: "select",
+      },
+      options: [undefined, "filled", "outlined"],
+    },
     onClick: {
       description: `Contained chip can have onClick event. When Chip is clickable, onDelete is disabled.`,
       control: {
@@ -80,6 +87,7 @@ export default {
   },
   args: {
     kind: "contained",
+    variant: "filled",
     label: "label@lunit.io",
   },
   parameters: {
@@ -116,9 +124,10 @@ export const Outlined = {
   args: {
     color: "primary",
     kind: "outlined",
+    variant: "outlined",
   },
 
-  name: "Kind: Outlined",
+  name: "Kind(Variant): Outlined",
 };
 
 export const Contained = {
@@ -138,9 +147,10 @@ export const Contained = {
   args: {
     color: "primary",
     kind: "contained",
+    variant: "filled",
   },
 
-  name: "Kind: Contained / Read Only",
+  name: "Kind(Variant): Contained / Read Only",
 };
 
 export const ContainedWithClick = {
@@ -161,7 +171,7 @@ export const ContainedWithClick = {
     },
   },
 
-  name: "Kind: Contained / Enable",
+  name: "Kind(Variant): Contained / Enable",
 };
 
 export const ContainedWithDelete = {
@@ -182,7 +192,7 @@ export const ContainedWithDelete = {
     },
   },
 
-  name: "Kind: Contained / Deletable",
+  name: "Kind(Variant): Contained / Deletable",
 };
 
 export const ContainedWithThumbnail = {
@@ -204,5 +214,5 @@ export const ContainedWithThumbnail = {
     },
   },
 
-  name: "Kind: Contained with Thumbnail",
+  name: "Kind(Variant): Contained with Thumbnail",
 };


### PR DESCRIPTION
### 작업 사항

[DS-104]

- chip 컴포넌트에 kind props의 alias로 variant 사용 선적용
- kind의 대체 props로 variant 적용 bd5f69cdcd41287151a66c28cd5aff3727b12f9d
- storybook에 variant 추가 6404ff03b396596e47fd838013333ea6f11cf454

- button 컴포넌트 variant 적용 [4fbbcc9](https://github.com/lunit-io/design-system/pull/150/commits/4fbbcc9cf494bf9ae1c2f821dfb0b4e79692912e)
- button storybook variant 변경 사항 적용 [f9a0f09](https://github.com/lunit-io/design-system/pull/150/commits/f9a0f09312023e59943fe6fd63b3fad95d6f4403)

### 참고 사항

- 히스토리 기록 차 [슬랙 논의 링크](https://lunit.slack.com/archives/C02FGSSMN7Q/p1701849864038259)를 걸어둡니다.
- Textfield는 현재 변경이 필요치 않은 상황이며, Button, Button Toggle은 본 PR에서 @LTakhyunKim 님이 이어 작업하시기로 하였습니다. 일단 Chip에서 선적용한 형태가 다른 컴포넌트에도 적절할지를 판단 부탁드립니다.


[DS-104]: https://lunit.atlassian.net/browse/DS-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ