### PR TITLE
[DS-115] Set default color for texts

### DIFF
--- a/apps/nextjs-test-system/components/MainBoard.tsx
+++ b/apps/nextjs-test-system/components/MainBoard.tsx
@@ -71,7 +71,6 @@ function MainBoard() {
           borderRadius: "0.75rem",
           backgroundColor: theme.palette.lunit_token.core.bg_01,
           marginBottom: "1.5rem",
-          color: theme.palette.lunit_token.core.text_normal,
           typography: "body2_14_regular",
         }}
       >

--- a/apps/nextjs-test-system/components/SidePanel.tsx
+++ b/apps/nextjs-test-system/components/SidePanel.tsx
@@ -60,7 +60,6 @@ function SidePanel() {
           background: theme.palette.lunit_token.component.scrollbars_bg,
         },
         borderLeft: "1px solid #000",
-        color: theme.palette.lunit_token.core.text_normal,
       }}
     >
       <Box sx={{ display: "flex" }}>

--- a/packages/design-system/src/foundation/Typography/index.ts
+++ b/packages/design-system/src/foundation/Typography/index.ts
@@ -86,6 +86,24 @@ export const createTypographyCssBaseline = () => {
     ":root": {
       ...cssVariables,
     },
+    ".light1": {
+      color: "var(--text_normal)",
+    },
+    ".light2": {
+      color: "var(--text_normal)",
+    },
+    ".dark1": {
+      color: "var(--text_normal)",
+    },
+    ".dark2": {
+      color: "var(--text_normal)",
+    },
+    ".dark3": {
+      color: "var(--text_normal)",
+    },
+    ".dark4": {
+      color: "var(--text_normal)",
+    },
   };
 };
 

--- a/packages/design-system/src/foundation/Typography/tokens.ts
+++ b/packages/design-system/src/foundation/Typography/tokens.ts
@@ -69,73 +69,61 @@ const fontVariants: Record<string, TypographyStyleOptions> = {
     fontWeight: "var(--headline1-font-weight)",
     fontSize: "var(--headline1-font-size)",
     lineHeight: "var(--headline1-line-height)",
-    color: "var(--text_normal)",
   },
   headline2: {
     fontWeight: "var(--headline2-font-weight)",
     fontSize: "var(--headline2-font-size)",
     lineHeight: "var(--headline2-line-height)",
-    color: "var(--text_normal)",
   },
   headline3: {
     fontWeight: "var(--headline3-font-weight)",
     fontSize: "var(--headline3-font-size)",
     lineHeight: "var(--headline3-line-height)",
-    color: "var(--text_normal)",
   },
   headline4: {
     fontWeight: "var(--headline4-font-weight)",
     fontSize: "var(--headline4-font-size)",
     lineHeight: "var(--headline4-line-height)",
-    color: "var(--text_normal)",
   },
   headline5: {
     fontWeight: "var(--headline5-font-weight)",
     fontSize: "var(--headline5-font-size)",
     lineHeight: "var(--headline5-line-height)",
-    color: "var(--text_normal)",
   },
   body1_16_semibold: {
     fontWeight: "var(--body1-16-semibold-font-weight)",
     fontSize: "var(--body1-16-semibold-font-size)",
     lineHeight: "var(--body1-16-semibold-line-height)",
-    color: "var(--text_normal)",
   },
   body1_16_regular: {
     fontWeight: "var(--body1-16-regular-font-weight)",
     fontSize: "var(--body1-16-regular-font-size)",
     lineHeight: "var(--body1-16-regular-line-height)",
-    color: "var(--text_normal)",
   },
   body2_14_bold: {
     fontWeight: "var(--body2-14-bold-font-weight)",
     fontSize: "var(--body2-14-bold-font-size)",
     lineHeight: "var(--body2-14-bold-line-height)",
-    color: "var(--text_normal)",
   },
   body2_14_medium: {
     fontWeight: "var(--body2-14-medium-font-weight)",
     fontSize: "var(--body2-14-medium-font-size)",
     lineHeight: "var(--body2-14-medium-line-height)",
-    color: "var(--text_normal)",
   },
   body2_14_regular: {
     fontWeight: "var(--body2-14-regular-font-weight)",
     fontSize: "var(--body2-14-regular-font-size)",
     lineHeight: "var(--body2-14-regular-line-height)",
-    color: "var(--text_normal)",
   },
   body3_12_semibold: {
     fontWeight: "var(--body3-12-semibold-font-weight)",
     fontSize: "var(--body3-12-semibold-font-size)",
     lineHeight: "var(--body3-12-semibold-line-height)",
-    color: "var(--text_normal)",
   },
   body3_12_regular: {
     fontWeight: "var(--body3-12-regular-font-weight)",
     fontSize: "var(--body3-12-regular-font-size)",
     lineHeight: "var(--body3-12-regular-line-height)",
-    color: "var(--text_normal)",
   },
   overline: {
     fontWeight: "var(--overline-font-weight)",
@@ -143,14 +131,12 @@ const fontVariants: Record<string, TypographyStyleOptions> = {
     lineHeight: "var(--overline-line-height)",
     letterSpacing: "1px",
     textTransform: "uppercase",
-    color: "var(--text_normal)",
   },
   button1: {
     fontWeight: "var(--button1-font-weight)",
     fontSize: "var(--button1-font-size)",
     lineHeight: "var(--button1-line-height)",
     textTransform: "capitalize",
-    color: "var(--text_normal)",
   },
   button2: {
     fontWeight: "var(--button2-font-weight)",
@@ -158,13 +144,11 @@ const fontVariants: Record<string, TypographyStyleOptions> = {
     lineHeight: "var(--button2-line-height)",
     letterSpacing: "0.2px",
     textTransform: "capitalize",
-    color: "var(--text_normal)",
   },
   caption: {
     fontWeight: "var(--caption-font-weight)",
     fontSize: "var(--caption-font-size)",
     lineHeight: "var(--caption-line-height)",
-    color: "var(--text_normal)",
   },
 };
 

--- a/packages/design-system/src/foundation/colors/index.ts
+++ b/packages/design-system/src/foundation/colors/index.ts
@@ -172,6 +172,10 @@ const paletteOptions = {
     main: base.green[40], // core.text_success.dark1
   },
   grey: base.greyForMUI,
+  text: {
+    primary: base.grey[5], // core.text_normal.dark1
+    secondary: base.grey[40], // core.text_medium.dark1
+  },
   lunit_global: lunitColors,
   lunit_token: {
     core: {

--- a/packages/design-system/src/foundation/index.ts
+++ b/packages/design-system/src/foundation/index.ts
@@ -9,7 +9,7 @@ import { createElevationCssBaseline, elevationOptions } from "./Elevation";
 
 export const foundationCssBaseline: Components<Theme>["MuiCssBaseline"] = {
   styleOverrides: deepmerge(
-    deepmerge(createTypographyCssBaseline(), createColorCssBaseline()),
+    deepmerge(createColorCssBaseline(), createTypographyCssBaseline()),
     createElevationCssBaseline()
   ),
 };


### PR DESCRIPTION
[DS-115]

각 Typography 컴포넌트마다 `color`를 지정한 #148 의 방식은 아래 문제가 있었습니다.
- 텍스트 컬러가 상위 스타일을 상속받지 못하기 때문에 사용이 불편함
- Typography 컴포넌트나 그 스타일을 적용하지 않은 일반 텍스트의 경우 `.light1`등 베이스를 지정하더라도 Mui의 기본 컬러를 따라감

이 때문에 각 베이스 클래스에 직접 `color`를 지정하였습니다. 
또한 베이스 클래스가 없는 경우 fallback으로 기본값인 dark1에 해당하는 솔리드 컬러를 지정하였습니다.

제대로 적용되는지 테스트를 위해 테스트시스템에 직접 입력하신 `text_normal` 컬러는 제거하였습니다 @HyejinYang 




[DS-115]: https://lunit.atlassian.net/browse/DS-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ