### PR TITLE
[DS-101] Button SVG 20px 적용

### DIFF
--- a/packages/design-system/src/components/Button/Button.styled.ts
+++ b/packages/design-system/src/components/Button/Button.styled.ts
@@ -211,14 +211,11 @@ export const iconStyle = ({
   hasIconOnly,
 }: Pick<CustomButtonProps, "size" | "hasIconOnly">) => ({
   "& .MuiButton-startIcon": {
-    width: "20px",
-    height: "20px",
-    padding: "1px",
     margin: 0,
     marginRight: hasIconOnly ? "0px" : size === "large" ? "8px" : "4px",
 
     "*:nth-of-type(1)": {
-      fontSize: "18px",
+      fontSize: "20px",
     },
   },
 });

--- a/packages/design-system/src/components/ToggleButton/ToggleButton.styled.ts
+++ b/packages/design-system/src/components/ToggleButton/ToggleButton.styled.ts
@@ -57,10 +57,9 @@ export const IconWrapper = styled("div")<{
 }>(({ hasIconOnly, size }) => ({
   width: "20px",
   height: "20px",
-  padding: "1px",
   marginRight: hasIconOnly ? "0px" : size === "large" ? "8px" : "4px",
 
   "*:nth-of-type(1)": {
-    fontSize: "18px",
+    fontSize: "20px",
   },
 }));


### PR DESCRIPTION
[DS-101](https://lunit.atlassian.net/browse/DS-101)

기존 Button SVG 20px 을 적용합니다.
이전 `18px` 로 적용된 부분으로 인해 아이콘 사이즈가 의도보다 작게 보이게 되었습니다.

불필요하게 적용되어 있던 `padding: 1px` 스타일도 삭제 조치했습니다.
위 1px 은 피그마 아이콘 자체에 내장된 것으로 확인하여 삭제했습니다.

- [Design System Button Figma](https://www.figma.com/file/BSdRUpEPp7XiJ9YnEqpf6F/1.0.0_Components?node-id=13510%3A220762&mode=dev)

[DS-101]: https://lunit.atlassian.net/browse/DS-101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ