### PR TITLE
[DS-119] esm

### DIFF
--- a/packages/design-system-icons/CHANGELOG.md
+++ b/packages/design-system-icons/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2024-01-22
+
+### Fixed
+
+- Use `import` instead of `require()` in ESM bundles
+
 ## [1.3.1] - 2023-10-03
 
 ### Fixed

--- a/packages/design-system-icons/package.json
+++ b/packages/design-system-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunit/design-system-icons",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Icons for Lunit design system",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",

--- a/packages/design-system-icons/webpack/base.config.js
+++ b/packages/design-system-icons/webpack/base.config.js
@@ -1,5 +1,3 @@
-const nodeExternals = require("webpack-node-externals");
-
 module.exports = {
   mode: "production",
   // Enable sourcemaps for debugging webpack's output.
@@ -19,11 +17,6 @@ module.exports = {
           configFile: "tsconfig.build.json",
         },
       },
-      // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-      {
-        test: /\.js$/,
-        loader: "source-map-loader",
-      },
       {
         test: /\.svg$/,
         issuer: /\.[jt]sx?$/,
@@ -31,9 +24,4 @@ module.exports = {
       },
     ],
   },
-  externals: [
-    nodeExternals({
-      modulesFromFile: true,
-    }),
-  ],
 };

--- a/packages/design-system-icons/webpack/cjs.config.js
+++ b/packages/design-system-icons/webpack/cjs.config.js
@@ -1,5 +1,6 @@
 const glob = require("fast-glob");
 const path = require("path");
+const nodeExternals = require("webpack-node-externals");
 
 const base = require("./base.config");
 
@@ -24,4 +25,9 @@ module.exports = {
       type: "commonjs2",
     },
   },
+  externals: [
+    nodeExternals({
+      modulesFromFile: true,
+    }),
+  ],
 };

--- a/packages/design-system-icons/webpack/esm.config.js
+++ b/packages/design-system-icons/webpack/esm.config.js
@@ -1,5 +1,6 @@
 const glob = require("fast-glob");
 const path = require("path");
+const nodeExternals = require("webpack-node-externals");
 
 const base = require("./base.config");
 
@@ -21,4 +22,10 @@ module.exports = {
       type: "module",
     },
   },
+  externals: [
+    nodeExternals({
+      modulesFromFile: true,
+      importType: "module",
+    }),
+  ],
 };


### PR DESCRIPTION
Fixes #153 

By default, [webpack-node-externals](https://www.npmjs.com/package/webpack-node-externals) applies the module's `importType` as `commonjs`. This option has issues with using `require()` in ESM bundles. 

This PR fixes it to use `import` as intended in ESM bundles.