### PR TITLE
[DS-165] Storybook 의 MUI Component 텍스트 컬러를 위한 theme 업데이트

### DIFF
--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { ThemeProvider, CssBaseline, Box } from "@mui/material";
+import { ThemeProvider, CssBaseline, Box, createTheme } from "@mui/material";
 
 import theme from "../src/theme";
 
@@ -6,8 +6,20 @@ export const decorators = [
   (Story, context) => {
     const surface = context.globals.theme;
 
+    // MUI component의 기본 text 컬러가 dark1 테마로 설정되어 있으나,
+    // modal과 같이 dom을 새로 생성하는 MUI 컴포넌트의 기본 배경색이 흰색이라 글자색이 보이지 않는 문제가 있어서
+    // storybook 내 MUI component의 가독성을 위해 text 컬러를 light1 컬러로 재지정
+    const custom_theme = createTheme(theme, {
+      palette: {
+        text: {
+          primary: "#111113", // core.text_normal.light1
+          secondary: "#626264", // core.text_medium.ligh1
+        },
+      },
+    });
+
     return (
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={custom_theme}>
         <CssBaseline />
         <Box
           className={surface}

--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { ThemeProvider, CssBaseline, Box, createTheme } from "@mui/material";
+import { deepmerge } from "@mui/utils";
 
-import theme from "../src/theme";
+import { themeOptions } from "../src/theme";
 import * as baseColor from "../src/foundation/colors/base";
 
 export const decorators = [
@@ -10,41 +11,43 @@ export const decorators = [
     // MUI component의 기본 text 컬러가 dark1 테마로 설정되어 있으나,
     // modal과 같이 dom을 새로 생성하는 MUI 컴포넌트의 기본 배경색이 흰색이라 글자색이 보이지 않는 문제가 있어서
     // storybook 내 MUI component의 가독성을 위해 MUI 기본 palette 컬러를 light1 컬러로 재지정
-    const custom_theme = createTheme(theme, {
-      palette: {
-        primary: {
-          main: baseColor.lunit_teal[50], // core.text_primary.light1
+    const custom_theme = createTheme(
+      deepmerge(themeOptions, {
+        palette: {
+          primary: {
+            main: baseColor.lunit_teal[30], // component.btn_primary_bg.light1
+          },
+          secondary: {
+            main: baseColor.grey[15], // component.btn_secondary_bg.light1
+          },
+          error: {
+            main: baseColor.red[30], // component.btn_error_bg.light1
+          },
+          warning: {
+            main: baseColor.orange[20], // component.chip_warning_bg.light1
+          },
+          info: {
+            main: baseColor.blue[10], // component.alert_info_bg.light1 와 비슷한 색....
+          },
+          success: {
+            main: baseColor.green[20], // component.chip_success_bg.light1
+          },
+          grey: baseColor.greyForMUI,
+          text: {
+            primary: baseColor.grey[95], // core.text_normal.light1
+            secondary: baseColor.grey[60], // core.text_medium.light1
+          },
         },
-        secondary: {
-          main: baseColor.grey[40], // core.text_light.light1
-        },
-        error: {
-          main: baseColor.red[40], // core.text_error.light1
-        },
-        warning: {
-          main: baseColor.orange[40], // core.text_warning.light1
-        },
-        info: {
-          main: baseColor.blue[40], // core.text_info.light1
-        },
-        success: {
-          main: baseColor.green[40], // core.text_success.light1
-        },
-        grey: baseColor.greyForMUI,
-        text: {
-          primary: baseColor.grey[95], // core.text_normal.light1
-          secondary: baseColor.grey[60], // core.text_medium.light1
-        },
-      },
-    });
+      })
+    );
 
     return (
       <ThemeProvider theme={custom_theme}>
         <CssBaseline />
         <Box
           className={surface}
-          bgcolor={theme.palette.lunit_token.core.bg_01}
-          color={theme.palette.lunit_token.core.text_normal}
+          bgcolor={custom_theme.palette.lunit_token.core.bg_01}
+          color={custom_theme.palette.lunit_token.core.text_normal}
           sx={{ p: 2 }}
         >
           <Story />

--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { ThemeProvider, CssBaseline, Box, createTheme } from "@mui/material";
 
 import theme from "../src/theme";
+import * as baseColor from "../src/foundation/colors/base";
 
 export const decorators = [
   (Story, context) => {
@@ -8,12 +9,31 @@ export const decorators = [
 
     // MUI component의 기본 text 컬러가 dark1 테마로 설정되어 있으나,
     // modal과 같이 dom을 새로 생성하는 MUI 컴포넌트의 기본 배경색이 흰색이라 글자색이 보이지 않는 문제가 있어서
-    // storybook 내 MUI component의 가독성을 위해 text 컬러를 light1 컬러로 재지정
+    // storybook 내 MUI component의 가독성을 위해 MUI 기본 palette 컬러를 light1 컬러로 재지정
     const custom_theme = createTheme(theme, {
       palette: {
+        primary: {
+          main: baseColor.lunit_teal[50], // core.text_primary.light1
+        },
+        secondary: {
+          main: baseColor.grey[40], // core.text_light.light1
+        },
+        error: {
+          main: baseColor.red[40], // core.text_error.light1
+        },
+        warning: {
+          main: baseColor.orange[40], // core.text_warning.light1
+        },
+        info: {
+          main: baseColor.blue[40], // core.text_info.light1
+        },
+        success: {
+          main: baseColor.green[40], // core.text_success.light1
+        },
+        grey: baseColor.greyForMUI,
         text: {
-          primary: "#111113", // core.text_normal.light1
-          secondary: "#626264", // core.text_medium.ligh1
+          primary: baseColor.grey[95], // core.text_normal.light1
+          secondary: baseColor.grey[60], // core.text_medium.light1
         },
       },
     });


### PR DESCRIPTION
Jira: [DS-165]

## Description

_Elevation_ 스토리북을 포함하여, MUI component 를 사용하고 있는 부분에서 텍스트 컬러가 흰색에 가까워 보이지 않는 현상 발생.

→ 현재 MUI 기본 palette text 색상이 dark1 테마의 색상인데, MUI component 의 기본 배경색은 흰색이라 발생하는 현상

→ Storybook 내 MUI component 의 ~text 기본 색상~ `default palette 컬러`를 `light1` 테마 색상으로 변경하여 가독성 올림
<br />
<br />

### 변경 전
![스크린샷 2024-02-05 오후 6 22 12](https://github.com/lunit-io/design-system/assets/43946483/23c1ddd2-5ea7-486f-8335-aab3f4998f64)

### 변경 후
![스크린샷 2024-02-05 오후 6 21 46](https://github.com/lunit-io/design-system/assets/43946483/4b65ae49-9467-4b9b-a3e7-310843810ce7)




[DS-165]: https://lunit.atlassian.net/browse/DS-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ