### PR TITLE
[DS-158] Chip documentation

### DIFF
--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Meta } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import { Box } from "@mui/system";
+
 import Chip from "@/components/Chip";
 import {
   Logo16,
@@ -157,6 +159,48 @@ export const Contained = {
   },
 
   name: "Kind(Variant): Contained / Read Only",
+};
+
+export const Kind = {
+  render: () => (
+    <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
+      <Chip kind="outlined" label="label@lunit.io" />
+      <Chip kind="contained" label="label@lunit.io" />
+    </Box>
+  ),
+};
+
+export const Color = {
+  render: () => (
+    <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
+      <Chip color="primary" label="label@lunit.io" />
+      <Chip color="secondary" label="label@lunit.io" />
+      <Chip color="warning" label="label@lunit.io" />
+      <Chip color="error" label="label@lunit.io" />
+      <Chip color="success" label="label@lunit.io" />
+    </Box>
+  ),
+};
+
+export const ReadOnlyAndEnable = {
+  render: () => (
+    <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
+      <Chip label="label@lunit.io" />
+      <Chip kind="outlined" label="label@lunit.io" />
+      <Chip label="label@lunit.io" onClick={() => console.log("onClick")} />
+    </Box>
+  ),
+};
+
+export const Thumbnail = {
+  render: () => (
+    <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
+      <Chip thumbnail={<Logo16 />} label="label@lunit.io" />
+      <Chip thumbnail={<Avatar16 />} label="label@lunit.io" />
+      <Chip thumbnail={<Success16 />} label="label@lunit.io" />
+      <Chip thumbnail="W as initial" label="label@lunit.io" />
+    </Box>
+  ),
 };
 
 export const ContainedWithClick = {

--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -162,6 +162,7 @@ export const Contained = {
 };
 
 export const Kind = {
+  chromatic: { disableSnapshot: true },
   render: () => (
     <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
       <Chip kind="outlined" label="label@lunit.io" />
@@ -171,6 +172,7 @@ export const Kind = {
 };
 
 export const Color = {
+  chromatic: { disableSnapshot: true },
   render: () => (
     <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
       <Chip color="primary" label="label@lunit.io" />
@@ -182,17 +184,8 @@ export const Color = {
   ),
 };
 
-export const ReadOnlyAndEnable = {
-  render: () => (
-    <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
-      <Chip label="label@lunit.io" />
-      <Chip kind="outlined" label="label@lunit.io" />
-      <Chip label="label@lunit.io" onClick={() => console.log("onClick")} />
-    </Box>
-  ),
-};
-
 export const Thumbnail = {
+  chromatic: { disableSnapshot: true },
   render: () => (
     <Box sx={{ display: "flex", flexDirection: "row", gap: 4 }}>
       <Chip thumbnail={<Logo16 />} label="label@lunit.io" />

--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -17,6 +17,10 @@ export default {
   argTypes: {
     kind: {
       description: `Default status of Contained or Outlined Chip is readOnly. You can pass onClick, onDelete or thumbnail to Contained Chip only.`,
+      control: {
+        type: "select",
+      },
+      options: ["contained", "outlined"],
     },
     variant: {
       description: `The variant is alias of kind. It is Filled or Outlined.`,

--- a/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
+++ b/packages/design-system/src/stories/components/Chip/Chip.stories.tsx
@@ -102,6 +102,8 @@ export default {
   },
 } as Meta<typeof Chip>;
 
+export const Basic = {};
+
 export const Outlined = {
   parameters: {
     docs: {
@@ -215,4 +217,26 @@ export const ContainedWithThumbnail = {
   },
 
   name: "Kind(Variant): Contained with Thumbnail",
+};
+
+export const ContainedWithDeleteAndThumbnail = {
+  args: {
+    ...Contained.args,
+    thumbnail: "Initial",
+    onClick: undefined,
+    onDelete: action("onDelete"),
+  },
+
+  parameters: {
+    docs: {
+      description: {
+        story: `Contained chip can have thumbnail and delete button.`,
+      },
+    },
+    controls: {
+      exclude: ["onClick"],
+    },
+  },
+
+  name: "Kind(Variant): Contained with Thumbnail and Deletable",
 };

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -106,7 +106,9 @@ The hover/pressed effects are only applied to the delete icon. <br />
 
 ### Thumbnail(logo, avatar, icon)
 
-Chips with the `thumbnail` prop can display a logo, avatar, or icon. <br />
+Chips with the thumbnail prop can display a logo, avatar, or icon. <br />
+The thumbnail replaces all the left side icons of MUI, so you cannot use the icon or avatar prop of the MUI system. <br />
+The thumbnail prop cannot be used when the kind (variant) is outlined.
 
 <Canvas of={ChipStories.ContainedWithThumbnail} />
 ```tsx

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -71,25 +71,6 @@ The default color is `primary`.
 <Chip color="success" label="label@lunit.io" />
 ```
 
-### ReadOnly and Enable
-
-Chips without the `onClick` or `onDelete` are read-only. <br />
-The default status of chips is read-only and will have no hover/pressed effects. <br />
-The `outlined` variant is always considered as read-only. <br />
-
-<Canvas of={ChipStories.ReadOnlyAndEnable} />
-```tsx
-
-// read-only
-
-<Chip label="label@lunit.io" />
-<Chip kind="outlined" label="label@lunit.io" />
-
-// enable with onClick
-
-<Chip label="label@lunit.io" onClick={() => console.log("onClick")} />
-```
-
 ### Clickable(enable)
 
 Chips with the `onClick` are clickable. <br />

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -38,12 +38,13 @@ If the label is not provided, the Chip will be rendered as a circle.
 <Chip label="label@lunit.io" />
 ````
 
-### Variant(kind)
+### Kind(variant)
 
-The Chip has 2 kinds of variants: `outlined` and `contained`. <br />
-(In the Lunit Design System, the variant and kind are used interchangeably. The kind is a fallback prop of the variant.) <br />
-You can change the variant of the Chip by using the `variant` or `kind` prop, and the outcome will be the same. <br />
-The default variant(kind) is `contained`. <br />
+The Chip has 2 kinds of variants: outlined and contained. <br />
+(In the Lunit Design System, the variant and kind are used interchangeably. The variant is a fallback prop of the kind.) <br />
+You can change the kind of the Chip by using the kind or variant prop, and the outcome will be the same.
+The `contained` kind corresponds to the `filled` and `contained` variants of the MUI system. <br />
+The default kind(variant) is contained. <br />
 
 <Canvas of={ChipStories.Kind} meta={ChipStories.Contained.meta} />
 ```tsx

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -71,7 +71,7 @@ The default color is `primary`.
 <Chip color="success" label="label@lunit.io" />
 ```
 
-### Clickable(enable)
+### Clickable
 
 Chips with the `onClick` are clickable. <br />
 You cannot pass the `onClick` prop to the Chip when its variant is `outlined`. <br />
@@ -82,7 +82,7 @@ You cannot pass the `onClick` prop to the Chip when its variant is `outlined`. <
 
 ````
 
-### Deletable(enable)
+### Deletable
 
 Chips with the `onDelete` are deletable. <br />
 You cannot pass the `onDelete` prop to the Chip when its variant is `outlined`. <br />

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -43,7 +43,7 @@ If the label is not provided, the Chip will be rendered as a circle.
 The Chip has 2 kinds of variants: `outlined` and `contained`. <br />
 (In the Lunit Design System, the variant and kind are used interchangeably. The kind is a fallback prop of the variant.) <br />
 You can change the variant of the Chip by using the `variant` or `kind` prop, and the outcome will be the same. <br />
-The default variant(kind) is `contained`, and it is read-only without the `onClick` prop. <br />
+The default variant(kind) is `contained`. <br />
 
 <Canvas of={ChipStories.Contained} meta={ChipStories.Contained.meta} />
 ```tsx
@@ -91,7 +91,7 @@ You cannot pass the `onClick` prop to the Chip when its variant is `outlined`. <
 
 ````
 
-#### Deletable(enable)
+### Deletable(enable)
 
 Chips with the `onDelete` are deletable. <br />
 You cannot pass the `onDelete` prop to the Chip when its variant is `outlined`. <br />

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -106,13 +106,13 @@ The hover/pressed effects are only applied to the delete icon. <br />
 
 ### Thumbnail(logo, avatar, icon)
 
-Chips with the thumbnail prop can display a logo, avatar, or icon. <br />
+Chips with the thumbnail prop can display a logo, avatar, icon, or the first letter of a string.<br />
 The thumbnail replaces all the left side icons of MUI, so you cannot use the icon or avatar prop of the MUI system. <br />
 The thumbnail prop cannot be used when the kind (variant) is outlined.
 
 <Canvas of={ChipStories.ContainedWithThumbnail} />
 ```tsx
-<Chip label="label@lunit.io" thumbnamil={<Error />} />
+<Chip label="label@lunit.io" thumbnamil="W as initial" />
 
 ````
 
@@ -123,7 +123,7 @@ The hover/pressed effects are only applied to the delete icon. <br />
 
 <Canvas of={ChipStories.ContainedWithDeleteAndThumbnail} />
 ```tsx
-<Chip label="label@lunit.io" onDelete={() => console.log("onDelete")} thumbnamil={<Error />} />
+<Chip label="label@lunit.io" onDelete={() => console.log("onDelete")} thumbnail="W as initial" />
 ````
 
 ## Reference

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -1,0 +1,136 @@
+import { Canvas, Stories, Controls, Meta, Story } from "@storybook/blocks";
+import { Error } from "@lunit/design-system-icons";
+
+import Chip from "@/components/Chip";
+import * as ChipStories from "./Chip.stories";
+
+<Meta name="Chip Docs" of={ChipStories} />
+
+# Chip
+
+Chips are compact elements that represent an input, attribute, or action.
+
+## Usage
+
+### Basic Chip
+
+```tsx
+import { Chip } from "@lunit/design-system";
+// or
+import Chip from "@lunit/design-system/Chip";
+
+<Chip />;
+```
+
+### Demo
+
+<Canvas of={ChipStories.Basic} />
+
+<Controls />
+
+### Label
+
+The label is the text that will be displayed in the Chip.
+If the label is not provided, the Chip will be rendered as a circle.
+
+<Canvas of={ChipStories.Contained} meta={ChipStories.Contained.meta} />
+```tsx
+<Chip label="label@lunit.io" />
+````
+
+### Variant(kind)
+
+The Chip has 2 kinds of variants: `outlined` and `contained`. <br />
+(In the Lunit Design System, the variant and kind are used interchangeably. The kind is a fallback prop of the variant.) <br />
+You can change the variant of the Chip by using the `variant` or `kind` prop, and the outcome will be the same. <br />
+The default variant(kind) is `contained`, and it is read-only without the `onClick` prop. <br />
+
+<Canvas of={ChipStories.Contained} meta={ChipStories.Contained.meta} />
+```tsx
+<Chip label="label@lunit.io" />
+
+<Chip variant="contained" label="label@lunit.io" />
+<Chip variant="outlined" label="label@lunit.io" />
+// or (kind is a fallback prop of the variant)
+<Chip kind="contained" label="label@lunit.io" />
+<Chip kind="outlined" label="label@lunit.io" />
+````
+
+### Color
+
+The Chip has 5 kinds of colors: `primary`, `secondary`, `warning`, `error`, and `success`. <br />
+By using the color prop, you can change the color of the Chip. <br />
+The default color is `primary`.
+
+```tsx
+<Chip label="label@lunit.io" />
+
+<Chip color="primary" label="label@lunit.io" />
+<Chip color="secondary" label="label@lunit.io" />
+<Chip color="warning" label="label@lunit.io" />
+<Chip color="error" label="label@lunit.io" />
+<Chip color="success" label="label@lunit.io" />
+```
+
+### ReadOnly and Enable
+
+Chips without the `onClick` or `onDelete` are read-only. <br />
+The default status of chips is read-only and will have no hover/pressed effects. <br />
+The `outlined` variant is always considered as read-only. <br />
+
+<Canvas of={ChipStories.Outlined} />
+
+### Clickable(enable)
+
+Chips with the `onClick` are clickable. <br />
+You cannot pass the `onClick` prop to the Chip when its variant is `outlined`. <br />
+
+<Canvas of={ChipStories.ContainedWithClick} />
+```tsx
+<Chip label="label@lunit.io" onClick={() => console.log("onClick")} />
+
+````
+
+#### Deletable(enable)
+
+Chips with the `onDelete` are deletable. <br />
+You cannot pass the `onDelete` prop to the Chip when its variant is `outlined`. <br />
+The hover/pressed effects are only applied to the delete icon. <br />
+
+<Canvas of={ChipStories.ContainedWithDelete} />
+
+```tsx
+<Chip label="label@lunit.io" onDelete={() => console.log("onDelete")} />
+
+````
+
+### Thumbnail(logo, avatar, icon)
+
+Chips with the `thumbnail` prop can display a logo, avatar, or icon. <br />
+
+<Canvas of={ChipStories.ContainedWithThumbnail} />
+```tsx
+<Chip label="label@lunit.io" thumbnamil={<Error />} />
+
+````
+
+### Thumbnail and Deletable
+
+The Chip can have a thumbnail and be deletable. <br />
+The hover/pressed effects are only applied to the delete icon. <br />
+
+<Canvas of={ChipStories.ContainedWithDeleteAndThumbnail} />
+```tsx
+<Chip label="label@lunit.io" onDelete={() => console.log("onDelete")} thumbnamil={<Error />} />
+````
+
+## Reference
+
+- [Material-UI Chip](https://mui.com/material-ui/react-chip/)
+- [Material-UI Chip API](https://mui.com/material-ui/api/chip/)
+- [Lunit Design System Chip Figma](https://www.figma.com/file/oh2WsSLBuX30Yp589gyliB/Design-System_1.0.7_Latest?type=design&node-id=1887-7970&mode=design)
+
+## Support
+
+- Github: [Create a new issue](https://github.com/lunit-io/design-system/issues/new)
+- Slack: #tf_design_system

--- a/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
+++ b/packages/design-system/src/stories/components/Chip/ChipDocs.mdx
@@ -45,10 +45,8 @@ The Chip has 2 kinds of variants: `outlined` and `contained`. <br />
 You can change the variant of the Chip by using the `variant` or `kind` prop, and the outcome will be the same. <br />
 The default variant(kind) is `contained`. <br />
 
-<Canvas of={ChipStories.Contained} meta={ChipStories.Contained.meta} />
+<Canvas of={ChipStories.Kind} meta={ChipStories.Contained.meta} />
 ```tsx
-<Chip label="label@lunit.io" />
-
 <Chip variant="contained" label="label@lunit.io" />
 <Chip variant="outlined" label="label@lunit.io" />
 // or (kind is a fallback prop of the variant)
@@ -62,9 +60,9 @@ The Chip has 5 kinds of colors: `primary`, `secondary`, `warning`, `error`, and 
 By using the color prop, you can change the color of the Chip. <br />
 The default color is `primary`.
 
-```tsx
-<Chip label="label@lunit.io" />
+<Canvas of={ChipStories.Color} meta={ChipStories.Contained.meta} />
 
+```tsx
 <Chip color="primary" label="label@lunit.io" />
 <Chip color="secondary" label="label@lunit.io" />
 <Chip color="warning" label="label@lunit.io" />
@@ -78,7 +76,18 @@ Chips without the `onClick` or `onDelete` are read-only. <br />
 The default status of chips is read-only and will have no hover/pressed effects. <br />
 The `outlined` variant is always considered as read-only. <br />
 
-<Canvas of={ChipStories.Outlined} />
+<Canvas of={ChipStories.ReadOnlyAndEnable} />
+```tsx
+
+// read-only
+
+<Chip label="label@lunit.io" />
+<Chip kind="outlined" label="label@lunit.io" />
+
+// enable with onClick
+
+<Chip label="label@lunit.io" onClick={() => console.log("onClick")} />
+```
 
 ### Clickable(enable)
 
@@ -104,15 +113,18 @@ The hover/pressed effects are only applied to the delete icon. <br />
 
 ````
 
-### Thumbnail(logo, avatar, icon)
+### Thumbnail(logo, avatar, icon, first letter)
 
 Chips with the thumbnail prop can display a logo, avatar, icon, or the first letter of a string.<br />
 The thumbnail replaces all the left side icons of MUI, so you cannot use the icon or avatar prop of the MUI system. <br />
 The thumbnail prop cannot be used when the kind (variant) is outlined.
 
-<Canvas of={ChipStories.ContainedWithThumbnail} />
+<Canvas of={ChipStories.Thumbnail} />
 ```tsx
-<Chip label="label@lunit.io" thumbnamil="W as initial" />
+<Chip thumbnail={<Logo16 />} label="label@lunit.io" />
+<Chip thumbnail={<Avatar16 />} label="label@lunit.io" />
+<Chip thumbnail={<Success16 />} label="label@lunit.io" />
+<Chip thumbnail="W as initial" label="label@lunit.io" />
 
 ````
 


### PR DESCRIPTION
Jira: [DS-158](https://lunit.atlassian.net/jira/software/projects/DS/boards/31?selectedIssue=DS-158)

## Description
Design System Chip에 대한 문서를 작성합니다.
참고: [Storybook 문서 양식](https://lunit.atlassian.net/wiki/spaces/~420757902/pages/3209625692)

- Basic과 ContainedWithDeleteAndThumbnail 스토리를 추가하는 등 기존 스토리북 추가
- Chip docs mdx 추가

## Additional Description

되도록 기존에 머지된 Button 스토리 양식을 따르려 했지만, 다소 어색한 표현이 있는 부분은 조금 더 이해가 쉽도록 고쳤으니 참고 부탁드립니다.  

[DS-158]: https://lunit.atlassian.net/browse/DS-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ